### PR TITLE
fix: transfer restrictions don't apply to minting or burning

### DIFF
--- a/contracts/src/HypercertMinter.sol
+++ b/contracts/src/HypercertMinter.sol
@@ -181,6 +181,17 @@ contract HypercertMinter is IHypercertToken, SemiFungible1155, AllowlistMinter, 
         bytes memory data
     ) internal virtual override(SemiFungible1155) {
         super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
+
+        // By-pass transfer restrictions for minting and burning
+        if (from == address(0)) {
+            // Minting
+            return;
+        } else if (to == address(0)) {
+            // Burning
+            return;
+        }
+
+        // Transfer case, where to and from are non-zero
         uint256 len = ids.length;
         for (uint256 i; i < len; ) {
             uint256 typeID = getBaseType(ids[i]);

--- a/contracts/test/foundry/HypercertMinter.t.sol
+++ b/contracts/test/foundry/HypercertMinter.t.sol
@@ -111,4 +111,32 @@ contract HypercertMinterTest is PRBTest, StdCheats, StdUtils, MinterTestHelper {
             IHypercertToken.TransferRestrictions.AllowAll
         );
     }
+
+    function testClaimTenFractionsDisallowAll() public {
+        uint256[] memory fractions = buildFractions(10);
+        uint256 totalUnits = getSum(fractions);
+        vm.expectEmit(true, true, true, true);
+        emit ClaimStored(1 << 128, _uri, totalUnits);
+        hypercertMinter.mintClaimWithFractions(
+            alice,
+            totalUnits,
+            fractions,
+            _uri,
+            IHypercertToken.TransferRestrictions.DisallowAll
+        );
+    }
+
+    function testClaimTenFractionsFromCreatorOnly() public {
+        uint256[] memory fractions = buildFractions(10);
+        uint256 totalUnits = getSum(fractions);
+        vm.expectEmit(true, true, true, true);
+        emit ClaimStored(1 << 128, _uri, totalUnits);
+        hypercertMinter.mintClaimWithFractions(
+            alice,
+            totalUnits,
+            fractions,
+            _uri,
+            IHypercertToken.TransferRestrictions.FromCreatorOnly
+        );
+    }
 }


### PR DESCRIPTION
* Previously, if the token restriction was set to DisallowAll or FromCreatorOnly, creating from an allowlist led to failures