### PR TITLE
fix: CSV parsing needs more trimming

### DIFF
--- a/frontend/hooks/mintClaimAllowlist.ts
+++ b/frontend/hooks/mintClaimAllowlist.ts
@@ -24,10 +24,8 @@ import { transferRestrictions } from "./mintClaim";
 const generateAndStoreTree = async (
   pairs: { address: string; fraction: number }[],
 ) => {
-  const tree = StandardMerkleTree.of(
-    pairs.map((p) => [p.address, p.fraction]),
-    ["address", "uint256"],
-  );
+  const tuples = pairs.map((p) => [p.address, p.fraction]);
+  const tree = StandardMerkleTree.of(tuples, ["address", "uint256"]);
   const cid = await storeData(JSON.stringify(tree.dump()));
   return { cid, root: tree.root as `0x{string}` };
 };

--- a/frontend/lib/parsing.ts
+++ b/frontend/lib/parsing.ts
@@ -4,11 +4,11 @@ import { assertNever } from "./common";
 
 export const parseCsv = (csv: string) => {
   const [headersRaw, ...rest] = csv.split("\n");
-  const headers = headersRaw.split(",");
+  const headers = headersRaw.split(",").map((x) => x.trim());
   return rest
-    .filter((row) => row !== "")
+    .filter((row) => row.trim() !== "")
     .map((row) => {
-      const values = row.split(",");
+      const values = row.split(",").map((x) => x.trim());
       return values.reduce(
         (result, value, currentIndex) => ({
           ...result,


### PR DESCRIPTION
* previously we didn't trim every element in the CSV parsing. That led to things like 'fractions \r' or '100.0 '
* Trimming will clean this right up!