### PR TITLE
fix: lowercase addresses

### DIFF
--- a/frontend/components/claim-all-fractions-button.tsx
+++ b/frontend/components/claim-all-fractions-button.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@mui/material";
 import { useRouter } from "next/router";
-import { useAccount } from "wagmi";
+import { useAccountLowerCase } from "../hooks/account";
 import {
   useGetAllEligibility,
   useMintFractionAllowlistBatch,
@@ -13,9 +13,10 @@ export const ClaimAllFractionsButton = ({
   text: string;
   className?: string;
 }) => {
-  const { address } = useAccount();
+  const { address } = useAccountLowerCase();
+
   const router = useRouter();
-  const { data: claimIds } = useGetAllEligibility(address || "");
+  const { data: claimIds } = useGetAllEligibility(address ?? "");
   const { write } = useMintFractionAllowlistBatch({
     onComplete: () => {
       console.log("Minted all of them");

--- a/frontend/components/connect-wallet.tsx
+++ b/frontend/components/connect-wallet.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { useAccount } from "wagmi";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { formatAddress } from "../lib/formatting";
+import { useAccountLowerCase } from "../hooks/account";
 
 export const ConnectWallet = () => {
-  const { address, isConnected } = useAccount();
+  const { address, isConnected } = useAccountLowerCase();
   /**
    * TODO: Sometimes the modal wont close when react strict mode is on.
    * Shouldn't happen in production because strict mode is turned off there

--- a/frontend/components/dapp-context.tsx
+++ b/frontend/components/dapp-context.tsx
@@ -9,7 +9,6 @@ import {
   configureChains,
   createClient,
   WagmiConfig,
-  useAccount,
   useNetwork,
   Chain,
 } from "wagmi";
@@ -19,6 +18,7 @@ import { DataProvider } from "@plasmicapp/loader-nextjs";
 import { DEFAULT_CHAIN_ID } from "../lib/config";
 import { ContractInteractionDialogProvider } from "./contract-interaction-dialog-context";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useAccountLowerCase } from "../hooks/account";
 
 const DAPP_CONTEXT_NAME = "DappContext";
 
@@ -48,7 +48,7 @@ export interface DappContextData {
 }
 
 export const DEFAULT_TEST_DATA: DappContextData = {
-  myAddress: "0x22E4b9b003Cc7B7149CF2135dfCe2BaddC7a534f",
+  myAddress: "0x22E4b9b003Cc7B7149CF2135dfCe2BaddC7a534f".toLowerCase(),
   defaultChainId: "5",
   chain: goerli,
   chains: ALL_CHAINS,
@@ -74,7 +74,7 @@ export function DappContext(props: DappContextProps) {
   } = props;
 
   const inEditor = React.useContext(PlasmicCanvasContext);
-  const { address } = useAccount();
+  const { address } = useAccountLowerCase();
   const { chain, chains } = useNetwork();
   const data: DappContextData =
     useTestData && testData && inEditor

--- a/frontend/components/hypercert-create.tsx
+++ b/frontend/components/hypercert-create.tsx
@@ -11,11 +11,11 @@ import { DATE_INDEFINITE, DateIndefinite, FormContext } from "./forms";
 import { useMintClaim } from "../hooks/mintClaim";
 import DappContext from "./dapp-context";
 import { formatHypercertData } from "@hypercerts-org/hypercerts-sdk";
-import { useAccount } from "wagmi";
 import { useMintClaimAllowlist } from "../hooks/mintClaimAllowlist";
 import { useRouter } from "next/router";
 import { useContractModal } from "./contract-interaction-dialog-context";
 import { parseListFromString } from "../lib/parsing";
+import { useAccountLowerCase } from "../hooks/account";
 
 /**
  * Constants
@@ -297,7 +297,7 @@ export function HypercertCreateForm(props: HypercertCreateFormProps) {
 
 export function HypercertCreateFormInner(props: HypercertCreateFormProps) {
   const { className, children } = props;
-  const { address } = useAccount();
+  const { address } = useAccountLowerCase();
   const { push } = useRouter();
   const { hideModal } = useContractModal();
 

--- a/frontend/hooks/account.ts
+++ b/frontend/hooks/account.ts
@@ -1,0 +1,12 @@
+import { useAccount } from "wagmi";
+
+/**
+ * Addresses come with uppercase from the hook. We use lowercase everywhere else
+ **/
+export function useAccountLowerCase() {
+  const data = useAccount();
+  return {
+    ...data,
+    address: data.address?.toLowerCase(),
+  };
+}

--- a/frontend/hooks/mintClaimAllowlist.ts
+++ b/frontend/hooks/mintClaimAllowlist.ts
@@ -76,7 +76,7 @@ export const useMintClaimAllowlist = ({
             const text = await data.text();
             const results = parseCsv(text);
             return results.map((row) => ({
-              address: row["address"],
+              address: row["address"].toLowerCase(),
               fraction: parseInt(row["fractions"], 10),
             }));
           },

--- a/frontend/hooks/mintFractionAllowlistBatch.ts
+++ b/frontend/hooks/mintFractionAllowlistBatch.ts
@@ -2,7 +2,6 @@ import { BigNumber } from "ethers";
 import { useParseBlockchainError } from "../lib/parse-blockchain-error";
 import { mintInteractionLabels } from "../content/chainInteractions";
 import {
-  useAccount,
   useContractWrite,
   usePrepareContractWrite,
   useWaitForTransaction,
@@ -15,6 +14,7 @@ import { CONTRACT_ADDRESS } from "../lib/config";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "../lib/supabase-client";
 import { toast } from "react-toastify";
+import { useAccountLowerCase } from "./account";
 
 export const useMintFractionAllowlistBatch = ({
   onComplete,
@@ -22,9 +22,9 @@ export const useMintFractionAllowlistBatch = ({
   onComplete?: () => void;
 }) => {
   const { setStep, showModal, hideModal } = useContractModal();
-  const { address } = useAccount();
+  const { address } = useAccountLowerCase();
 
-  const { data: claimIds } = useGetAllEligibility(address || "");
+  const { data: claimIds } = useGetAllEligibility(address ?? "");
   const parseBlockchainError = useParseBlockchainError();
 
   const [_units, setUnits] = useState<BigNumber[]>();


### PR DESCRIPTION
* This has been messing with us since day 1. useAccount returns back addresses that are a mix of upper and lower case.
* Added a new useAccountLowerCase that will lowercase the address.
* Plumb this everywhere so that we're always using lowercase addresses