### PR TITLE
fix: adds a 5 minute timeout to the claim all fractions button after

### DIFF
--- a/frontend/components/claim-all-fractions-button.tsx
+++ b/frontend/components/claim-all-fractions-button.tsx
@@ -6,6 +6,9 @@ import {
   useMintFractionAllowlistBatch,
 } from "../hooks/mintFractionAllowlistBatch";
 
+const LOCALSTORAGE_KEY = "claimAllFractionsTime";
+const DELAY = 5 * 60 * 1000; // 5 minutes
+
 export const ClaimAllFractionsButton = ({
   text = "Claim all fractions",
   className,
@@ -20,12 +23,21 @@ export const ClaimAllFractionsButton = ({
   const { write } = useMintFractionAllowlistBatch({
     onComplete: () => {
       console.log("Minted all of them");
+      // Store the current time
+      window.localStorage.setItem(LOCALSTORAGE_KEY, `${Date.now()}`);
       router.reload();
     },
   });
+
+  // Check if we need to wait (been less than DELAY since last claim)
+  const lastClaimStr = localStorage.getItem(LOCALSTORAGE_KEY);
+  const needToWait = lastClaimStr
+    ? Date.now() < parseInt(lastClaimStr) + DELAY
+    : false;
+
   return (
     <Button
-      disabled={!claimIds?.length}
+      disabled={!claimIds?.length || needToWait}
       className={className}
       onClick={() => write()}
       variant="outlined"


### PR DESCRIPTION
success

* The timeout should not affect failed claim attempts.
* Previously after success, it would still show as clickable because it takes time to propagate from Ethereum => Defender => Supabase. If a user clicks at that point, it would fail because we just claimed