### PR TITLE
feat: Add support for web3.storage

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,6 +1,6 @@
 {
   "**/*.{js,jsx,ts,tsx}": [
-    "eslint --ignore-path .gitignore",
+    "eslint --ignore-path .gitignore --ignore-pattern sdk/",
     "prettier --write --ignore-path .gitignore"
   ],
   "**/*.json": [

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more details, check out our [website](https://hypercerts.org/).
 ## Organization
 
 - `/contracts`: Smart contracts (Foundry+Hardhat)
-  - Deployed manually via hardhat tasks
+  - Manually deployed via hardhat tasks
 - `/cors-proxy`: CORS proxy for Cloudflare Workers
   - [via GitHub actions](https://github.com/hypercerts-org/hypercerts/actions/workflows/deploy-cors-proxy.yml)
 - `/defender`: OpenZeppelin Defender integration

--- a/sdk/.env.template
+++ b/sdk/.env.template
@@ -1,2 +1,3 @@
 GRAPH_URL="https://example.com"
 NFT_STORAGE_TOKEN="your-api-token"
+WEB3_STORAGE_TOKEN="your-api-token"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -4,9 +4,12 @@
 
 ### Configuration
 
-1. Copy `.env.template` to `.env`
-2. Create an API key on [NFT.Storage](https://nft.storage/) by going [here](https://nft.storage/manage). Add this to your config.
+1. Obtain your own storage keys. We use both NFT.storage (for NFT metadata) and web3.storage (for other data).
+  - Create an API key on [NFT.Storage](https://nft.storage/) by going [here](https://nft.storage/manage). Add this to your config.
+  - Create an API key on [web3.storage](https://web3.storage/) by going [here](https://web3.storage/manage). Add this to your config.
 
+2. Configure your keys
+  - Copy `.env.template` to `.env` and add your keys.
 
 ### Dependencies
 
@@ -20,14 +23,10 @@ yarn install
 yarn build
 ```
 
-`yarn lerna run bootstrap`
-
-`yarn lerna run tsc`
-
 ## Interface
 
 [API documentation](/docs/API.md)
-[Graph playground](https://thegraph.com/hosted-service/subgraph/bitbeckers/hypercerts-dev)
+[Graph playground](https://thegraph.com/hosted-service/subgraph/hypercerts-admin/hypercerts-testnet)
 
 ## Packages
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -28,7 +28,8 @@
     "mime": "^3.0.0",
     "nft.storage": "^7.0.0",
     "ts-jest": "^29.0.3",
-    "ts-mocha": "^10.0.0"
+    "ts-mocha": "^10.0.0",
+    "web3.storage": "^4.4.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",

--- a/sdk/src/.graphclient/index.ts
+++ b/sdk/src/.graphclient/index.ts
@@ -1,34 +1,38 @@
 // @ts-nocheck
-import { GraphQLResolveInfo, SelectionSetNode, FieldNode, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
-import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
-import { gql } from '@graphql-mesh/utils';
+import { GraphQLResolveInfo, SelectionSetNode, FieldNode, GraphQLScalarType, GraphQLScalarTypeConfig } from "graphql";
+import { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+import { gql } from "@graphql-mesh/utils";
 
-import type { GetMeshOptions } from '@graphql-mesh/runtime';
-import type { YamlConfig } from '@graphql-mesh/types';
-import { PubSub } from '@graphql-mesh/utils';
-import { DefaultLogger } from '@graphql-mesh/utils';
+import type { GetMeshOptions } from "@graphql-mesh/runtime";
+import type { YamlConfig } from "@graphql-mesh/types";
+import { PubSub } from "@graphql-mesh/utils";
+import { DefaultLogger } from "@graphql-mesh/utils";
 import MeshCache from "@graphql-mesh/cache-localforage";
-import { fetch as fetchFn } from '@whatwg-node/fetch';
+import { fetch as fetchFn } from "@whatwg-node/fetch";
 
-import { MeshResolvedSource } from '@graphql-mesh/runtime';
-import { MeshTransform, MeshPlugin } from '@graphql-mesh/types';
-import GraphqlHandler from "@graphql-mesh/graphql"
+import { MeshResolvedSource } from "@graphql-mesh/runtime";
+import { MeshTransform, MeshPlugin } from "@graphql-mesh/types";
+import GraphqlHandler from "@graphql-mesh/graphql";
 import BareMerger from "@graphql-mesh/merger-bare";
-import { printWithCache } from '@graphql-mesh/utils';
-import { createMeshHTTPHandler, MeshHTTPHandler } from '@graphql-mesh/http';
-import { getMesh, ExecuteMeshFn, SubscribeMeshFn, MeshContext as BaseMeshContext, MeshInstance } from '@graphql-mesh/runtime';
-import { MeshStore, FsStoreStorageAdapter } from '@graphql-mesh/store';
-import { path as pathModule } from '@graphql-mesh/cross-helpers';
-import { ImportFn } from '@graphql-mesh/types';
-import type { HypercertsDevTypes } from './sources/hypercerts-dev/types';
+import { printWithCache } from "@graphql-mesh/utils";
+import { createMeshHTTPHandler, MeshHTTPHandler } from "@graphql-mesh/http";
+import {
+  getMesh,
+  ExecuteMeshFn,
+  SubscribeMeshFn,
+  MeshContext as BaseMeshContext,
+  MeshInstance,
+} from "@graphql-mesh/runtime";
+import { MeshStore, FsStoreStorageAdapter } from "@graphql-mesh/store";
+import { path as pathModule } from "@graphql-mesh/cross-helpers";
+import { ImportFn } from "@graphql-mesh/types";
+import type { HypercertsDevTypes } from "./sources/hypercerts-dev/types";
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
-
-
 
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -43,62 +47,62 @@ export type Scalars = {
 };
 
 export type Allowlist = {
-  id: Scalars['String'];
-  root: Scalars['Bytes'];
+  id: Scalars["String"];
+  root: Scalars["Bytes"];
   claim: Claim;
 };
 
 export type Allowlist_filter = {
-  id?: InputMaybe<Scalars['String']>;
-  id_not?: InputMaybe<Scalars['String']>;
-  id_gt?: InputMaybe<Scalars['String']>;
-  id_lt?: InputMaybe<Scalars['String']>;
-  id_gte?: InputMaybe<Scalars['String']>;
-  id_lte?: InputMaybe<Scalars['String']>;
-  id_in?: InputMaybe<Array<Scalars['String']>>;
-  id_not_in?: InputMaybe<Array<Scalars['String']>>;
-  id_contains?: InputMaybe<Scalars['String']>;
-  id_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_not_contains?: InputMaybe<Scalars['String']>;
-  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_starts_with?: InputMaybe<Scalars['String']>;
-  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_starts_with?: InputMaybe<Scalars['String']>;
-  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_ends_with?: InputMaybe<Scalars['String']>;
-  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_ends_with?: InputMaybe<Scalars['String']>;
-  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  root?: InputMaybe<Scalars['Bytes']>;
-  root_not?: InputMaybe<Scalars['Bytes']>;
-  root_gt?: InputMaybe<Scalars['Bytes']>;
-  root_lt?: InputMaybe<Scalars['Bytes']>;
-  root_gte?: InputMaybe<Scalars['Bytes']>;
-  root_lte?: InputMaybe<Scalars['Bytes']>;
-  root_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  root_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  root_contains?: InputMaybe<Scalars['Bytes']>;
-  root_not_contains?: InputMaybe<Scalars['Bytes']>;
-  claim?: InputMaybe<Scalars['String']>;
-  claim_not?: InputMaybe<Scalars['String']>;
-  claim_gt?: InputMaybe<Scalars['String']>;
-  claim_lt?: InputMaybe<Scalars['String']>;
-  claim_gte?: InputMaybe<Scalars['String']>;
-  claim_lte?: InputMaybe<Scalars['String']>;
-  claim_in?: InputMaybe<Array<Scalars['String']>>;
-  claim_not_in?: InputMaybe<Array<Scalars['String']>>;
-  claim_contains?: InputMaybe<Scalars['String']>;
-  claim_contains_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_contains?: InputMaybe<Scalars['String']>;
-  claim_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  claim_starts_with?: InputMaybe<Scalars['String']>;
-  claim_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_starts_with?: InputMaybe<Scalars['String']>;
-  claim_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_ends_with?: InputMaybe<Scalars['String']>;
-  claim_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_ends_with?: InputMaybe<Scalars['String']>;
-  claim_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars["String"]>;
+  id_not?: InputMaybe<Scalars["String"]>;
+  id_gt?: InputMaybe<Scalars["String"]>;
+  id_lt?: InputMaybe<Scalars["String"]>;
+  id_gte?: InputMaybe<Scalars["String"]>;
+  id_lte?: InputMaybe<Scalars["String"]>;
+  id_in?: InputMaybe<Array<Scalars["String"]>>;
+  id_not_in?: InputMaybe<Array<Scalars["String"]>>;
+  id_contains?: InputMaybe<Scalars["String"]>;
+  id_contains_nocase?: InputMaybe<Scalars["String"]>;
+  id_not_contains?: InputMaybe<Scalars["String"]>;
+  id_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+  id_starts_with?: InputMaybe<Scalars["String"]>;
+  id_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  id_not_starts_with?: InputMaybe<Scalars["String"]>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  id_ends_with?: InputMaybe<Scalars["String"]>;
+  id_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  id_not_ends_with?: InputMaybe<Scalars["String"]>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  root?: InputMaybe<Scalars["Bytes"]>;
+  root_not?: InputMaybe<Scalars["Bytes"]>;
+  root_gt?: InputMaybe<Scalars["Bytes"]>;
+  root_lt?: InputMaybe<Scalars["Bytes"]>;
+  root_gte?: InputMaybe<Scalars["Bytes"]>;
+  root_lte?: InputMaybe<Scalars["Bytes"]>;
+  root_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+  root_not_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+  root_contains?: InputMaybe<Scalars["Bytes"]>;
+  root_not_contains?: InputMaybe<Scalars["Bytes"]>;
+  claim?: InputMaybe<Scalars["String"]>;
+  claim_not?: InputMaybe<Scalars["String"]>;
+  claim_gt?: InputMaybe<Scalars["String"]>;
+  claim_lt?: InputMaybe<Scalars["String"]>;
+  claim_gte?: InputMaybe<Scalars["String"]>;
+  claim_lte?: InputMaybe<Scalars["String"]>;
+  claim_in?: InputMaybe<Array<Scalars["String"]>>;
+  claim_not_in?: InputMaybe<Array<Scalars["String"]>>;
+  claim_contains?: InputMaybe<Scalars["String"]>;
+  claim_contains_nocase?: InputMaybe<Scalars["String"]>;
+  claim_not_contains?: InputMaybe<Scalars["String"]>;
+  claim_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+  claim_starts_with?: InputMaybe<Scalars["String"]>;
+  claim_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  claim_not_starts_with?: InputMaybe<Scalars["String"]>;
+  claim_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  claim_ends_with?: InputMaybe<Scalars["String"]>;
+  claim_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  claim_not_ends_with?: InputMaybe<Scalars["String"]>;
+  claim_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
   claim_?: InputMaybe<Claim_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
@@ -107,107 +111,115 @@ export type Allowlist_filter = {
 };
 
 export type Allowlist_orderBy =
-  | 'id'
-  | 'root'
-  | 'claim';
+  | "id"
+  | "root"
+  | "claim"
+  | "claim__id"
+  | "claim__creation"
+  | "claim__tokenID"
+  | "claim__contract"
+  | "claim__uri"
+  | "claim__creator"
+  | "claim__owner"
+  | "claim__totalUnits";
 
 export type BlockChangedFilter = {
-  number_gte: Scalars['Int'];
+  number_gte: Scalars["Int"];
 };
 
 export type Block_height = {
-  hash?: InputMaybe<Scalars['Bytes']>;
-  number?: InputMaybe<Scalars['Int']>;
-  number_gte?: InputMaybe<Scalars['Int']>;
+  hash?: InputMaybe<Scalars["Bytes"]>;
+  number?: InputMaybe<Scalars["Int"]>;
+  number_gte?: InputMaybe<Scalars["Int"]>;
 };
 
 export type Claim = {
-  id: Scalars['String'];
-  creation: Scalars['BigInt'];
-  tokenID: Scalars['BigInt'];
-  contract: Scalars['String'];
-  uri?: Maybe<Scalars['String']>;
-  creator?: Maybe<Scalars['Bytes']>;
-  owner?: Maybe<Scalars['Bytes']>;
-  totalUnits?: Maybe<Scalars['BigInt']>;
+  id: Scalars["String"];
+  creation: Scalars["BigInt"];
+  tokenID: Scalars["BigInt"];
+  contract: Scalars["String"];
+  uri?: Maybe<Scalars["String"]>;
+  creator?: Maybe<Scalars["Bytes"]>;
+  owner?: Maybe<Scalars["Bytes"]>;
+  totalUnits?: Maybe<Scalars["BigInt"]>;
 };
 
 export type ClaimToken = {
-  id: Scalars['String'];
-  tokenID: Scalars['BigInt'];
+  id: Scalars["String"];
+  tokenID: Scalars["BigInt"];
   claim: Claim;
-  owner: Scalars['Bytes'];
-  units: Scalars['BigInt'];
+  owner: Scalars["Bytes"];
+  units: Scalars["BigInt"];
 };
 
 export type ClaimToken_filter = {
-  id?: InputMaybe<Scalars['String']>;
-  id_not?: InputMaybe<Scalars['String']>;
-  id_gt?: InputMaybe<Scalars['String']>;
-  id_lt?: InputMaybe<Scalars['String']>;
-  id_gte?: InputMaybe<Scalars['String']>;
-  id_lte?: InputMaybe<Scalars['String']>;
-  id_in?: InputMaybe<Array<Scalars['String']>>;
-  id_not_in?: InputMaybe<Array<Scalars['String']>>;
-  id_contains?: InputMaybe<Scalars['String']>;
-  id_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_not_contains?: InputMaybe<Scalars['String']>;
-  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_starts_with?: InputMaybe<Scalars['String']>;
-  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_starts_with?: InputMaybe<Scalars['String']>;
-  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_ends_with?: InputMaybe<Scalars['String']>;
-  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_ends_with?: InputMaybe<Scalars['String']>;
-  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  tokenID?: InputMaybe<Scalars['BigInt']>;
-  tokenID_not?: InputMaybe<Scalars['BigInt']>;
-  tokenID_gt?: InputMaybe<Scalars['BigInt']>;
-  tokenID_lt?: InputMaybe<Scalars['BigInt']>;
-  tokenID_gte?: InputMaybe<Scalars['BigInt']>;
-  tokenID_lte?: InputMaybe<Scalars['BigInt']>;
-  tokenID_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  tokenID_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  claim?: InputMaybe<Scalars['String']>;
-  claim_not?: InputMaybe<Scalars['String']>;
-  claim_gt?: InputMaybe<Scalars['String']>;
-  claim_lt?: InputMaybe<Scalars['String']>;
-  claim_gte?: InputMaybe<Scalars['String']>;
-  claim_lte?: InputMaybe<Scalars['String']>;
-  claim_in?: InputMaybe<Array<Scalars['String']>>;
-  claim_not_in?: InputMaybe<Array<Scalars['String']>>;
-  claim_contains?: InputMaybe<Scalars['String']>;
-  claim_contains_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_contains?: InputMaybe<Scalars['String']>;
-  claim_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  claim_starts_with?: InputMaybe<Scalars['String']>;
-  claim_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_starts_with?: InputMaybe<Scalars['String']>;
-  claim_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_ends_with?: InputMaybe<Scalars['String']>;
-  claim_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_ends_with?: InputMaybe<Scalars['String']>;
-  claim_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars["String"]>;
+  id_not?: InputMaybe<Scalars["String"]>;
+  id_gt?: InputMaybe<Scalars["String"]>;
+  id_lt?: InputMaybe<Scalars["String"]>;
+  id_gte?: InputMaybe<Scalars["String"]>;
+  id_lte?: InputMaybe<Scalars["String"]>;
+  id_in?: InputMaybe<Array<Scalars["String"]>>;
+  id_not_in?: InputMaybe<Array<Scalars["String"]>>;
+  id_contains?: InputMaybe<Scalars["String"]>;
+  id_contains_nocase?: InputMaybe<Scalars["String"]>;
+  id_not_contains?: InputMaybe<Scalars["String"]>;
+  id_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+  id_starts_with?: InputMaybe<Scalars["String"]>;
+  id_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  id_not_starts_with?: InputMaybe<Scalars["String"]>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  id_ends_with?: InputMaybe<Scalars["String"]>;
+  id_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  id_not_ends_with?: InputMaybe<Scalars["String"]>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  tokenID?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_not?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_gt?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_lt?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_gte?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_lte?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+  tokenID_not_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+  claim?: InputMaybe<Scalars["String"]>;
+  claim_not?: InputMaybe<Scalars["String"]>;
+  claim_gt?: InputMaybe<Scalars["String"]>;
+  claim_lt?: InputMaybe<Scalars["String"]>;
+  claim_gte?: InputMaybe<Scalars["String"]>;
+  claim_lte?: InputMaybe<Scalars["String"]>;
+  claim_in?: InputMaybe<Array<Scalars["String"]>>;
+  claim_not_in?: InputMaybe<Array<Scalars["String"]>>;
+  claim_contains?: InputMaybe<Scalars["String"]>;
+  claim_contains_nocase?: InputMaybe<Scalars["String"]>;
+  claim_not_contains?: InputMaybe<Scalars["String"]>;
+  claim_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+  claim_starts_with?: InputMaybe<Scalars["String"]>;
+  claim_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  claim_not_starts_with?: InputMaybe<Scalars["String"]>;
+  claim_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  claim_ends_with?: InputMaybe<Scalars["String"]>;
+  claim_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  claim_not_ends_with?: InputMaybe<Scalars["String"]>;
+  claim_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
   claim_?: InputMaybe<Claim_filter>;
-  owner?: InputMaybe<Scalars['Bytes']>;
-  owner_not?: InputMaybe<Scalars['Bytes']>;
-  owner_gt?: InputMaybe<Scalars['Bytes']>;
-  owner_lt?: InputMaybe<Scalars['Bytes']>;
-  owner_gte?: InputMaybe<Scalars['Bytes']>;
-  owner_lte?: InputMaybe<Scalars['Bytes']>;
-  owner_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  owner_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  owner_contains?: InputMaybe<Scalars['Bytes']>;
-  owner_not_contains?: InputMaybe<Scalars['Bytes']>;
-  units?: InputMaybe<Scalars['BigInt']>;
-  units_not?: InputMaybe<Scalars['BigInt']>;
-  units_gt?: InputMaybe<Scalars['BigInt']>;
-  units_lt?: InputMaybe<Scalars['BigInt']>;
-  units_gte?: InputMaybe<Scalars['BigInt']>;
-  units_lte?: InputMaybe<Scalars['BigInt']>;
-  units_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  units_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  owner?: InputMaybe<Scalars["Bytes"]>;
+  owner_not?: InputMaybe<Scalars["Bytes"]>;
+  owner_gt?: InputMaybe<Scalars["Bytes"]>;
+  owner_lt?: InputMaybe<Scalars["Bytes"]>;
+  owner_gte?: InputMaybe<Scalars["Bytes"]>;
+  owner_lte?: InputMaybe<Scalars["Bytes"]>;
+  owner_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+  owner_not_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+  owner_contains?: InputMaybe<Scalars["Bytes"]>;
+  owner_not_contains?: InputMaybe<Scalars["Bytes"]>;
+  units?: InputMaybe<Scalars["BigInt"]>;
+  units_not?: InputMaybe<Scalars["BigInt"]>;
+  units_gt?: InputMaybe<Scalars["BigInt"]>;
+  units_lt?: InputMaybe<Scalars["BigInt"]>;
+  units_gte?: InputMaybe<Scalars["BigInt"]>;
+  units_lte?: InputMaybe<Scalars["BigInt"]>;
+  units_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+  units_not_in?: InputMaybe<Array<Scalars["BigInt"]>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<ClaimToken_filter>>>;
@@ -215,137 +227,135 @@ export type ClaimToken_filter = {
 };
 
 export type ClaimToken_orderBy =
-  | 'id'
-  | 'tokenID'
-  | 'claim'
-  | 'owner'
-  | 'units';
+  | "id"
+  | "tokenID"
+  | "claim"
+  | "claim__id"
+  | "claim__creation"
+  | "claim__tokenID"
+  | "claim__contract"
+  | "claim__uri"
+  | "claim__creator"
+  | "claim__owner"
+  | "claim__totalUnits"
+  | "owner"
+  | "units";
 
 export type Claim_filter = {
-  id?: InputMaybe<Scalars['String']>;
-  id_not?: InputMaybe<Scalars['String']>;
-  id_gt?: InputMaybe<Scalars['String']>;
-  id_lt?: InputMaybe<Scalars['String']>;
-  id_gte?: InputMaybe<Scalars['String']>;
-  id_lte?: InputMaybe<Scalars['String']>;
-  id_in?: InputMaybe<Array<Scalars['String']>>;
-  id_not_in?: InputMaybe<Array<Scalars['String']>>;
-  id_contains?: InputMaybe<Scalars['String']>;
-  id_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_not_contains?: InputMaybe<Scalars['String']>;
-  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_starts_with?: InputMaybe<Scalars['String']>;
-  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_starts_with?: InputMaybe<Scalars['String']>;
-  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_ends_with?: InputMaybe<Scalars['String']>;
-  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_ends_with?: InputMaybe<Scalars['String']>;
-  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  creation?: InputMaybe<Scalars['BigInt']>;
-  creation_not?: InputMaybe<Scalars['BigInt']>;
-  creation_gt?: InputMaybe<Scalars['BigInt']>;
-  creation_lt?: InputMaybe<Scalars['BigInt']>;
-  creation_gte?: InputMaybe<Scalars['BigInt']>;
-  creation_lte?: InputMaybe<Scalars['BigInt']>;
-  creation_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  creation_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  tokenID?: InputMaybe<Scalars['BigInt']>;
-  tokenID_not?: InputMaybe<Scalars['BigInt']>;
-  tokenID_gt?: InputMaybe<Scalars['BigInt']>;
-  tokenID_lt?: InputMaybe<Scalars['BigInt']>;
-  tokenID_gte?: InputMaybe<Scalars['BigInt']>;
-  tokenID_lte?: InputMaybe<Scalars['BigInt']>;
-  tokenID_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  tokenID_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  contract?: InputMaybe<Scalars['String']>;
-  contract_not?: InputMaybe<Scalars['String']>;
-  contract_gt?: InputMaybe<Scalars['String']>;
-  contract_lt?: InputMaybe<Scalars['String']>;
-  contract_gte?: InputMaybe<Scalars['String']>;
-  contract_lte?: InputMaybe<Scalars['String']>;
-  contract_in?: InputMaybe<Array<Scalars['String']>>;
-  contract_not_in?: InputMaybe<Array<Scalars['String']>>;
-  contract_contains?: InputMaybe<Scalars['String']>;
-  contract_contains_nocase?: InputMaybe<Scalars['String']>;
-  contract_not_contains?: InputMaybe<Scalars['String']>;
-  contract_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  contract_starts_with?: InputMaybe<Scalars['String']>;
-  contract_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  contract_not_starts_with?: InputMaybe<Scalars['String']>;
-  contract_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  contract_ends_with?: InputMaybe<Scalars['String']>;
-  contract_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  contract_not_ends_with?: InputMaybe<Scalars['String']>;
-  contract_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  uri?: InputMaybe<Scalars['String']>;
-  uri_not?: InputMaybe<Scalars['String']>;
-  uri_gt?: InputMaybe<Scalars['String']>;
-  uri_lt?: InputMaybe<Scalars['String']>;
-  uri_gte?: InputMaybe<Scalars['String']>;
-  uri_lte?: InputMaybe<Scalars['String']>;
-  uri_in?: InputMaybe<Array<Scalars['String']>>;
-  uri_not_in?: InputMaybe<Array<Scalars['String']>>;
-  uri_contains?: InputMaybe<Scalars['String']>;
-  uri_contains_nocase?: InputMaybe<Scalars['String']>;
-  uri_not_contains?: InputMaybe<Scalars['String']>;
-  uri_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  uri_starts_with?: InputMaybe<Scalars['String']>;
-  uri_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  uri_not_starts_with?: InputMaybe<Scalars['String']>;
-  uri_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  uri_ends_with?: InputMaybe<Scalars['String']>;
-  uri_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  uri_not_ends_with?: InputMaybe<Scalars['String']>;
-  uri_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  creator?: InputMaybe<Scalars['Bytes']>;
-  creator_not?: InputMaybe<Scalars['Bytes']>;
-  creator_gt?: InputMaybe<Scalars['Bytes']>;
-  creator_lt?: InputMaybe<Scalars['Bytes']>;
-  creator_gte?: InputMaybe<Scalars['Bytes']>;
-  creator_lte?: InputMaybe<Scalars['Bytes']>;
-  creator_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  creator_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  creator_contains?: InputMaybe<Scalars['Bytes']>;
-  creator_not_contains?: InputMaybe<Scalars['Bytes']>;
-  owner?: InputMaybe<Scalars['Bytes']>;
-  owner_not?: InputMaybe<Scalars['Bytes']>;
-  owner_gt?: InputMaybe<Scalars['Bytes']>;
-  owner_lt?: InputMaybe<Scalars['Bytes']>;
-  owner_gte?: InputMaybe<Scalars['Bytes']>;
-  owner_lte?: InputMaybe<Scalars['Bytes']>;
-  owner_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  owner_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  owner_contains?: InputMaybe<Scalars['Bytes']>;
-  owner_not_contains?: InputMaybe<Scalars['Bytes']>;
-  totalUnits?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_not?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_gt?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_lt?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_gte?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_lte?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalUnits_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
+  id?: InputMaybe<Scalars["String"]>;
+  id_not?: InputMaybe<Scalars["String"]>;
+  id_gt?: InputMaybe<Scalars["String"]>;
+  id_lt?: InputMaybe<Scalars["String"]>;
+  id_gte?: InputMaybe<Scalars["String"]>;
+  id_lte?: InputMaybe<Scalars["String"]>;
+  id_in?: InputMaybe<Array<Scalars["String"]>>;
+  id_not_in?: InputMaybe<Array<Scalars["String"]>>;
+  id_contains?: InputMaybe<Scalars["String"]>;
+  id_contains_nocase?: InputMaybe<Scalars["String"]>;
+  id_not_contains?: InputMaybe<Scalars["String"]>;
+  id_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+  id_starts_with?: InputMaybe<Scalars["String"]>;
+  id_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  id_not_starts_with?: InputMaybe<Scalars["String"]>;
+  id_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  id_ends_with?: InputMaybe<Scalars["String"]>;
+  id_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  id_not_ends_with?: InputMaybe<Scalars["String"]>;
+  id_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  creation?: InputMaybe<Scalars["BigInt"]>;
+  creation_not?: InputMaybe<Scalars["BigInt"]>;
+  creation_gt?: InputMaybe<Scalars["BigInt"]>;
+  creation_lt?: InputMaybe<Scalars["BigInt"]>;
+  creation_gte?: InputMaybe<Scalars["BigInt"]>;
+  creation_lte?: InputMaybe<Scalars["BigInt"]>;
+  creation_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+  creation_not_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+  tokenID?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_not?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_gt?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_lt?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_gte?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_lte?: InputMaybe<Scalars["BigInt"]>;
+  tokenID_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+  tokenID_not_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+  contract?: InputMaybe<Scalars["String"]>;
+  contract_not?: InputMaybe<Scalars["String"]>;
+  contract_gt?: InputMaybe<Scalars["String"]>;
+  contract_lt?: InputMaybe<Scalars["String"]>;
+  contract_gte?: InputMaybe<Scalars["String"]>;
+  contract_lte?: InputMaybe<Scalars["String"]>;
+  contract_in?: InputMaybe<Array<Scalars["String"]>>;
+  contract_not_in?: InputMaybe<Array<Scalars["String"]>>;
+  contract_contains?: InputMaybe<Scalars["String"]>;
+  contract_contains_nocase?: InputMaybe<Scalars["String"]>;
+  contract_not_contains?: InputMaybe<Scalars["String"]>;
+  contract_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+  contract_starts_with?: InputMaybe<Scalars["String"]>;
+  contract_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  contract_not_starts_with?: InputMaybe<Scalars["String"]>;
+  contract_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  contract_ends_with?: InputMaybe<Scalars["String"]>;
+  contract_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  contract_not_ends_with?: InputMaybe<Scalars["String"]>;
+  contract_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  uri?: InputMaybe<Scalars["String"]>;
+  uri_not?: InputMaybe<Scalars["String"]>;
+  uri_gt?: InputMaybe<Scalars["String"]>;
+  uri_lt?: InputMaybe<Scalars["String"]>;
+  uri_gte?: InputMaybe<Scalars["String"]>;
+  uri_lte?: InputMaybe<Scalars["String"]>;
+  uri_in?: InputMaybe<Array<Scalars["String"]>>;
+  uri_not_in?: InputMaybe<Array<Scalars["String"]>>;
+  uri_contains?: InputMaybe<Scalars["String"]>;
+  uri_contains_nocase?: InputMaybe<Scalars["String"]>;
+  uri_not_contains?: InputMaybe<Scalars["String"]>;
+  uri_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+  uri_starts_with?: InputMaybe<Scalars["String"]>;
+  uri_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  uri_not_starts_with?: InputMaybe<Scalars["String"]>;
+  uri_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+  uri_ends_with?: InputMaybe<Scalars["String"]>;
+  uri_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  uri_not_ends_with?: InputMaybe<Scalars["String"]>;
+  uri_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+  creator?: InputMaybe<Scalars["Bytes"]>;
+  creator_not?: InputMaybe<Scalars["Bytes"]>;
+  creator_gt?: InputMaybe<Scalars["Bytes"]>;
+  creator_lt?: InputMaybe<Scalars["Bytes"]>;
+  creator_gte?: InputMaybe<Scalars["Bytes"]>;
+  creator_lte?: InputMaybe<Scalars["Bytes"]>;
+  creator_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+  creator_not_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+  creator_contains?: InputMaybe<Scalars["Bytes"]>;
+  creator_not_contains?: InputMaybe<Scalars["Bytes"]>;
+  owner?: InputMaybe<Scalars["Bytes"]>;
+  owner_not?: InputMaybe<Scalars["Bytes"]>;
+  owner_gt?: InputMaybe<Scalars["Bytes"]>;
+  owner_lt?: InputMaybe<Scalars["Bytes"]>;
+  owner_gte?: InputMaybe<Scalars["Bytes"]>;
+  owner_lte?: InputMaybe<Scalars["Bytes"]>;
+  owner_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+  owner_not_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+  owner_contains?: InputMaybe<Scalars["Bytes"]>;
+  owner_not_contains?: InputMaybe<Scalars["Bytes"]>;
+  totalUnits?: InputMaybe<Scalars["BigInt"]>;
+  totalUnits_not?: InputMaybe<Scalars["BigInt"]>;
+  totalUnits_gt?: InputMaybe<Scalars["BigInt"]>;
+  totalUnits_lt?: InputMaybe<Scalars["BigInt"]>;
+  totalUnits_gte?: InputMaybe<Scalars["BigInt"]>;
+  totalUnits_lte?: InputMaybe<Scalars["BigInt"]>;
+  totalUnits_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+  totalUnits_not_in?: InputMaybe<Array<Scalars["BigInt"]>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Claim_filter>>>;
   or?: InputMaybe<Array<InputMaybe<Claim_filter>>>;
 };
 
-export type Claim_orderBy =
-  | 'id'
-  | 'creation'
-  | 'tokenID'
-  | 'contract'
-  | 'uri'
-  | 'creator'
-  | 'owner'
-  | 'totalUnits';
+export type Claim_orderBy = "id" | "creation" | "tokenID" | "contract" | "uri" | "creator" | "owner" | "totalUnits";
 
 /** Defines the order direction, either ascending or descending */
-export type OrderDirection =
-  | 'asc'
-  | 'desc';
+export type OrderDirection = "asc" | "desc";
 
 export type Query = {
   allowlist?: Maybe<Allowlist>;
@@ -358,17 +368,15 @@ export type Query = {
   _meta?: Maybe<_Meta_>;
 };
 
-
 export type QueryallowlistArgs = {
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryallowlistsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars["Int"]>;
+  first?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<Allowlist_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Allowlist_filter>;
@@ -376,17 +384,15 @@ export type QueryallowlistsArgs = {
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryclaimArgs = {
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryclaimsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars["Int"]>;
+  first?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<Claim_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Claim_filter>;
@@ -394,24 +400,21 @@ export type QueryclaimsArgs = {
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryclaimTokenArgs = {
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryclaimTokensArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars["Int"]>;
+  first?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<ClaimToken_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<ClaimToken_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type Query_metaArgs = {
   block?: InputMaybe<Block_height>;
@@ -428,17 +431,15 @@ export type Subscription = {
   _meta?: Maybe<_Meta_>;
 };
 
-
 export type SubscriptionallowlistArgs = {
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionallowlistsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars["Int"]>;
+  first?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<Allowlist_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Allowlist_filter>;
@@ -446,17 +447,15 @@ export type SubscriptionallowlistsArgs = {
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionclaimArgs = {
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionclaimsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars["Int"]>;
+  first?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<Claim_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Claim_filter>;
@@ -464,17 +463,15 @@ export type SubscriptionclaimsArgs = {
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionclaimTokenArgs = {
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionclaimTokensArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars["Int"]>;
+  first?: InputMaybe<Scalars["Int"]>;
   orderBy?: InputMaybe<ClaimToken_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<ClaimToken_filter>;
@@ -482,18 +479,17 @@ export type SubscriptionclaimTokensArgs = {
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type Subscription_metaArgs = {
   block?: InputMaybe<Block_height>;
 };
 
 export type _Block_ = {
   /** The hash of the block */
-  hash?: Maybe<Scalars['Bytes']>;
+  hash?: Maybe<Scalars["Bytes"]>;
   /** The block number */
-  number: Scalars['Int'];
+  number: Scalars["Int"];
   /** Integer representation of the timestamp stored in blocks for the chain */
-  timestamp?: Maybe<Scalars['Int']>;
+  timestamp?: Maybe<Scalars["Int"]>;
 };
 
 /** The type for the top-level _meta field */
@@ -507,22 +503,21 @@ export type _Meta_ = {
    */
   block: _Block_;
   /** The deployment ID */
-  deployment: Scalars['String'];
+  deployment: Scalars["String"];
   /** If `true`, the subgraph encountered indexing errors at some past block */
-  hasIndexingErrors: Scalars['Boolean'];
+  hasIndexingErrors: Scalars["Boolean"];
 };
 
 export type _SubgraphErrorPolicy_ =
   /** Data will be returned even if the subgraph has indexing errors */
-  | 'allow'
+  | "allow"
   /** If the subgraph has indexing errors, data will be omitted. The default. */
-  | 'deny';
+  | "deny";
 
 export type WithIndex<TObject> = TObject & Record<string, any>;
 export type ResolversObject<TObject> = WithIndex<TObject>;
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
-
 
 export type ResolverWithResolve<TResult, TParent, TContext, TArgs> = {
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
@@ -537,7 +532,9 @@ export type NewStitchingResolver<TResult, TParent, TContext, TArgs> = {
   selectionSet: string | ((fieldNode: FieldNode) => SelectionSetNode);
   resolve: ResolverFn<TResult, TParent, TContext, TArgs>;
 };
-export type StitchingResolver<TResult, TParent, TContext, TArgs> = LegacyStitchingResolver<TResult, TParent, TContext, TArgs> | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
+export type StitchingResolver<TResult, TParent, TContext, TArgs> =
+  | LegacyStitchingResolver<TResult, TParent, TContext, TArgs>
+  | NewStitchingResolver<TResult, TParent, TContext, TArgs>;
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> =
   | ResolverFn<TResult, TParent, TContext, TArgs>
   | ResolverWithResolve<TResult, TParent, TContext, TArgs>
@@ -547,21 +544,21 @@ export type ResolverFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ) => Promise<TResult> | TResult;
 
 export type SubscriptionSubscribeFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ) => AsyncIterable<TResult> | Promise<AsyncIterable<TResult>>;
 
 export type SubscriptionResolveFn<TResult, TParent, TContext, TArgs> = (
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ) => TResult | Promise<TResult>;
 
 export interface SubscriptionSubscriberObject<TResult, TKey extends string, TParent, TContext, TArgs> {
@@ -585,10 +582,14 @@ export type SubscriptionResolver<TResult, TKey extends string, TParent = {}, TCo
 export type TypeResolveFn<TTypes, TParent = {}, TContext = {}> = (
   parent: TParent,
   context: TContext,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ) => Maybe<TTypes> | Promise<Maybe<TTypes>>;
 
-export type IsTypeOfResolverFn<T = {}, TContext = {}> = (obj: T, context: TContext, info: GraphQLResolveInfo) => boolean | Promise<boolean>;
+export type IsTypeOfResolverFn<T = {}, TContext = {}> = (
+  obj: T,
+  context: TContext,
+  info: GraphQLResolveInfo,
+) => boolean | Promise<boolean>;
 
 export type NextResolverFn<T> = () => Promise<T>;
 
@@ -597,7 +598,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   parent: TParent,
   args: TArgs,
   context: TContext,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ) => TResult | Promise<TResult>;
 
 /** Mapping between all available schema types and the resolvers types */
@@ -605,24 +606,24 @@ export type ResolversTypes = ResolversObject<{
   Allowlist: ResolverTypeWrapper<Allowlist>;
   Allowlist_filter: Allowlist_filter;
   Allowlist_orderBy: Allowlist_orderBy;
-  BigDecimal: ResolverTypeWrapper<Scalars['BigDecimal']>;
-  BigInt: ResolverTypeWrapper<Scalars['BigInt']>;
+  BigDecimal: ResolverTypeWrapper<Scalars["BigDecimal"]>;
+  BigInt: ResolverTypeWrapper<Scalars["BigInt"]>;
   BlockChangedFilter: BlockChangedFilter;
   Block_height: Block_height;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
-  Bytes: ResolverTypeWrapper<Scalars['Bytes']>;
+  Boolean: ResolverTypeWrapper<Scalars["Boolean"]>;
+  Bytes: ResolverTypeWrapper<Scalars["Bytes"]>;
   Claim: ResolverTypeWrapper<Claim>;
   ClaimToken: ResolverTypeWrapper<ClaimToken>;
   ClaimToken_filter: ClaimToken_filter;
   ClaimToken_orderBy: ClaimToken_orderBy;
   Claim_filter: Claim_filter;
   Claim_orderBy: Claim_orderBy;
-  Float: ResolverTypeWrapper<Scalars['Float']>;
-  ID: ResolverTypeWrapper<Scalars['ID']>;
-  Int: ResolverTypeWrapper<Scalars['Int']>;
+  Float: ResolverTypeWrapper<Scalars["Float"]>;
+  ID: ResolverTypeWrapper<Scalars["ID"]>;
+  Int: ResolverTypeWrapper<Scalars["Int"]>;
   OrderDirection: OrderDirection;
   Query: ResolverTypeWrapper<{}>;
-  String: ResolverTypeWrapper<Scalars['String']>;
+  String: ResolverTypeWrapper<Scalars["String"]>;
   Subscription: ResolverTypeWrapper<{}>;
   _Block_: ResolverTypeWrapper<_Block_>;
   _Meta_: ResolverTypeWrapper<_Meta_>;
@@ -633,113 +634,221 @@ export type ResolversTypes = ResolversObject<{
 export type ResolversParentTypes = ResolversObject<{
   Allowlist: Allowlist;
   Allowlist_filter: Allowlist_filter;
-  BigDecimal: Scalars['BigDecimal'];
-  BigInt: Scalars['BigInt'];
+  BigDecimal: Scalars["BigDecimal"];
+  BigInt: Scalars["BigInt"];
   BlockChangedFilter: BlockChangedFilter;
   Block_height: Block_height;
-  Boolean: Scalars['Boolean'];
-  Bytes: Scalars['Bytes'];
+  Boolean: Scalars["Boolean"];
+  Bytes: Scalars["Bytes"];
   Claim: Claim;
   ClaimToken: ClaimToken;
   ClaimToken_filter: ClaimToken_filter;
   Claim_filter: Claim_filter;
-  Float: Scalars['Float'];
-  ID: Scalars['ID'];
-  Int: Scalars['Int'];
+  Float: Scalars["Float"];
+  ID: Scalars["ID"];
+  Int: Scalars["Int"];
   Query: {};
-  String: Scalars['String'];
+  String: Scalars["String"];
   Subscription: {};
   _Block_: _Block_;
   _Meta_: _Meta_;
 }>;
 
-export type entityDirectiveArgs = { };
+export type entityDirectiveArgs = {};
 
-export type entityDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = entityDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type entityDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = MeshContext,
+  Args = entityDirectiveArgs,
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type subgraphIdDirectiveArgs = {
-  id: Scalars['String'];
+  id: Scalars["String"];
 };
 
-export type subgraphIdDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = subgraphIdDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type subgraphIdDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = MeshContext,
+  Args = subgraphIdDirectiveArgs,
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type derivedFromDirectiveArgs = {
-  field: Scalars['String'];
+  field: Scalars["String"];
 };
 
-export type derivedFromDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = derivedFromDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
+export type derivedFromDirectiveResolver<
+  Result,
+  Parent,
+  ContextType = MeshContext,
+  Args = derivedFromDirectiveArgs,
+> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
-export type AllowlistResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Allowlist'] = ResolversParentTypes['Allowlist']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  root?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
-  claim?: Resolver<ResolversTypes['Claim'], ParentType, ContextType>;
+export type AllowlistResolvers<
+  ContextType = MeshContext,
+  ParentType extends ResolversParentTypes["Allowlist"] = ResolversParentTypes["Allowlist"],
+> = ResolversObject<{
+  id?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  root?: Resolver<ResolversTypes["Bytes"], ParentType, ContextType>;
+  claim?: Resolver<ResolversTypes["Claim"], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
-export interface BigDecimalScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['BigDecimal'], any> {
-  name: 'BigDecimal';
+export interface BigDecimalScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes["BigDecimal"], any> {
+  name: "BigDecimal";
 }
 
-export interface BigIntScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['BigInt'], any> {
-  name: 'BigInt';
+export interface BigIntScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes["BigInt"], any> {
+  name: "BigInt";
 }
 
-export interface BytesScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Bytes'], any> {
-  name: 'Bytes';
+export interface BytesScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes["Bytes"], any> {
+  name: "Bytes";
 }
 
-export type ClaimResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Claim'] = ResolversParentTypes['Claim']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  creation?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  tokenID?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  contract?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  uri?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  creator?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
-  owner?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
-  totalUnits?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+export type ClaimResolvers<
+  ContextType = MeshContext,
+  ParentType extends ResolversParentTypes["Claim"] = ResolversParentTypes["Claim"],
+> = ResolversObject<{
+  id?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  creation?: Resolver<ResolversTypes["BigInt"], ParentType, ContextType>;
+  tokenID?: Resolver<ResolversTypes["BigInt"], ParentType, ContextType>;
+  contract?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  uri?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  creator?: Resolver<Maybe<ResolversTypes["Bytes"]>, ParentType, ContextType>;
+  owner?: Resolver<Maybe<ResolversTypes["Bytes"]>, ParentType, ContextType>;
+  totalUnits?: Resolver<Maybe<ResolversTypes["BigInt"]>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
-export type ClaimTokenResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['ClaimToken'] = ResolversParentTypes['ClaimToken']> = ResolversObject<{
-  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  tokenID?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
-  claim?: Resolver<ResolversTypes['Claim'], ParentType, ContextType>;
-  owner?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
-  units?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+export type ClaimTokenResolvers<
+  ContextType = MeshContext,
+  ParentType extends ResolversParentTypes["ClaimToken"] = ResolversParentTypes["ClaimToken"],
+> = ResolversObject<{
+  id?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  tokenID?: Resolver<ResolversTypes["BigInt"], ParentType, ContextType>;
+  claim?: Resolver<ResolversTypes["Claim"], ParentType, ContextType>;
+  owner?: Resolver<ResolversTypes["Bytes"], ParentType, ContextType>;
+  units?: Resolver<ResolversTypes["BigInt"], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
-export type QueryResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
-  allowlist?: Resolver<Maybe<ResolversTypes['Allowlist']>, ParentType, ContextType, RequireFields<QueryallowlistArgs, 'id' | 'subgraphError'>>;
-  allowlists?: Resolver<Array<ResolversTypes['Allowlist']>, ParentType, ContextType, RequireFields<QueryallowlistsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  claim?: Resolver<Maybe<ResolversTypes['Claim']>, ParentType, ContextType, RequireFields<QueryclaimArgs, 'id' | 'subgraphError'>>;
-  claims?: Resolver<Array<ResolversTypes['Claim']>, ParentType, ContextType, RequireFields<QueryclaimsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  claimToken?: Resolver<Maybe<ResolversTypes['ClaimToken']>, ParentType, ContextType, RequireFields<QueryclaimTokenArgs, 'id' | 'subgraphError'>>;
-  claimTokens?: Resolver<Array<ResolversTypes['ClaimToken']>, ParentType, ContextType, RequireFields<QueryclaimTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
-  _meta?: Resolver<Maybe<ResolversTypes['_Meta_']>, ParentType, ContextType, Partial<Query_metaArgs>>;
+export type QueryResolvers<
+  ContextType = MeshContext,
+  ParentType extends ResolversParentTypes["Query"] = ResolversParentTypes["Query"],
+> = ResolversObject<{
+  allowlist?: Resolver<
+    Maybe<ResolversTypes["Allowlist"]>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryallowlistArgs, "id" | "subgraphError">
+  >;
+  allowlists?: Resolver<
+    Array<ResolversTypes["Allowlist"]>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryallowlistsArgs, "skip" | "first" | "subgraphError">
+  >;
+  claim?: Resolver<
+    Maybe<ResolversTypes["Claim"]>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryclaimArgs, "id" | "subgraphError">
+  >;
+  claims?: Resolver<
+    Array<ResolversTypes["Claim"]>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryclaimsArgs, "skip" | "first" | "subgraphError">
+  >;
+  claimToken?: Resolver<
+    Maybe<ResolversTypes["ClaimToken"]>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryclaimTokenArgs, "id" | "subgraphError">
+  >;
+  claimTokens?: Resolver<
+    Array<ResolversTypes["ClaimToken"]>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryclaimTokensArgs, "skip" | "first" | "subgraphError">
+  >;
+  _meta?: Resolver<Maybe<ResolversTypes["_Meta_"]>, ParentType, ContextType, Partial<Query_metaArgs>>;
 }>;
 
-export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Subscription'] = ResolversParentTypes['Subscription']> = ResolversObject<{
-  allowlist?: SubscriptionResolver<Maybe<ResolversTypes['Allowlist']>, "allowlist", ParentType, ContextType, RequireFields<SubscriptionallowlistArgs, 'id' | 'subgraphError'>>;
-  allowlists?: SubscriptionResolver<Array<ResolversTypes['Allowlist']>, "allowlists", ParentType, ContextType, RequireFields<SubscriptionallowlistsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  claim?: SubscriptionResolver<Maybe<ResolversTypes['Claim']>, "claim", ParentType, ContextType, RequireFields<SubscriptionclaimArgs, 'id' | 'subgraphError'>>;
-  claims?: SubscriptionResolver<Array<ResolversTypes['Claim']>, "claims", ParentType, ContextType, RequireFields<SubscriptionclaimsArgs, 'skip' | 'first' | 'subgraphError'>>;
-  claimToken?: SubscriptionResolver<Maybe<ResolversTypes['ClaimToken']>, "claimToken", ParentType, ContextType, RequireFields<SubscriptionclaimTokenArgs, 'id' | 'subgraphError'>>;
-  claimTokens?: SubscriptionResolver<Array<ResolversTypes['ClaimToken']>, "claimTokens", ParentType, ContextType, RequireFields<SubscriptionclaimTokensArgs, 'skip' | 'first' | 'subgraphError'>>;
-  _meta?: SubscriptionResolver<Maybe<ResolversTypes['_Meta_']>, "_meta", ParentType, ContextType, Partial<Subscription_metaArgs>>;
+export type SubscriptionResolvers<
+  ContextType = MeshContext,
+  ParentType extends ResolversParentTypes["Subscription"] = ResolversParentTypes["Subscription"],
+> = ResolversObject<{
+  allowlist?: SubscriptionResolver<
+    Maybe<ResolversTypes["Allowlist"]>,
+    "allowlist",
+    ParentType,
+    ContextType,
+    RequireFields<SubscriptionallowlistArgs, "id" | "subgraphError">
+  >;
+  allowlists?: SubscriptionResolver<
+    Array<ResolversTypes["Allowlist"]>,
+    "allowlists",
+    ParentType,
+    ContextType,
+    RequireFields<SubscriptionallowlistsArgs, "skip" | "first" | "subgraphError">
+  >;
+  claim?: SubscriptionResolver<
+    Maybe<ResolversTypes["Claim"]>,
+    "claim",
+    ParentType,
+    ContextType,
+    RequireFields<SubscriptionclaimArgs, "id" | "subgraphError">
+  >;
+  claims?: SubscriptionResolver<
+    Array<ResolversTypes["Claim"]>,
+    "claims",
+    ParentType,
+    ContextType,
+    RequireFields<SubscriptionclaimsArgs, "skip" | "first" | "subgraphError">
+  >;
+  claimToken?: SubscriptionResolver<
+    Maybe<ResolversTypes["ClaimToken"]>,
+    "claimToken",
+    ParentType,
+    ContextType,
+    RequireFields<SubscriptionclaimTokenArgs, "id" | "subgraphError">
+  >;
+  claimTokens?: SubscriptionResolver<
+    Array<ResolversTypes["ClaimToken"]>,
+    "claimTokens",
+    ParentType,
+    ContextType,
+    RequireFields<SubscriptionclaimTokensArgs, "skip" | "first" | "subgraphError">
+  >;
+  _meta?: SubscriptionResolver<
+    Maybe<ResolversTypes["_Meta_"]>,
+    "_meta",
+    ParentType,
+    ContextType,
+    Partial<Subscription_metaArgs>
+  >;
 }>;
 
-export type _Block_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Block_'] = ResolversParentTypes['_Block_']> = ResolversObject<{
-  hash?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
-  number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  timestamp?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+export type _Block_Resolvers<
+  ContextType = MeshContext,
+  ParentType extends ResolversParentTypes["_Block_"] = ResolversParentTypes["_Block_"],
+> = ResolversObject<{
+  hash?: Resolver<Maybe<ResolversTypes["Bytes"]>, ParentType, ContextType>;
+  number?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  timestamp?: Resolver<Maybe<ResolversTypes["Int"]>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
-export type _Meta_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Meta_'] = ResolversParentTypes['_Meta_']> = ResolversObject<{
-  block?: Resolver<ResolversTypes['_Block_'], ParentType, ContextType>;
-  deployment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  hasIndexingErrors?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+export type _Meta_Resolvers<
+  ContextType = MeshContext,
+  ParentType extends ResolversParentTypes["_Meta_"] = ResolversParentTypes["_Meta_"],
+> = ResolversObject<{
+  block?: Resolver<ResolversTypes["_Block_"], ParentType, ContextType>;
+  deployment?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  hasIndexingErrors?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -764,69 +873,75 @@ export type DirectiveResolvers<ContextType = MeshContext> = ResolversObject<{
 
 export type MeshContext = HypercertsDevTypes.Context & BaseMeshContext;
 
-
-const baseDir = pathModule.join(typeof __dirname === 'string' ? __dirname : '/', '..');
+const baseDir = pathModule.join(typeof __dirname === "string" ? __dirname : "/", "..");
 
 const importFn: ImportFn = <T>(moduleId: string) => {
-  const relativeModuleId = (pathModule.isAbsolute(moduleId) ? pathModule.relative(baseDir, moduleId) : moduleId).split('\\').join('/').replace(baseDir + '/', '');
-  switch(relativeModuleId) {
+  const relativeModuleId = (pathModule.isAbsolute(moduleId) ? pathModule.relative(baseDir, moduleId) : moduleId)
+    .split("\\")
+    .join("/")
+    .replace(baseDir + "/", "");
+  switch (relativeModuleId) {
     case ".graphclient/sources/hypercerts-dev/introspectionSchema":
       return import("./sources/hypercerts-dev/introspectionSchema") as T;
-    
+
     default:
       return Promise.reject(new Error(`Cannot find module '${relativeModuleId}'.`));
   }
 };
 
-const rootStore = new MeshStore('.graphclient', new FsStoreStorageAdapter({
-  cwd: baseDir,
-  importFn,
-  fileType: "ts",
-}), {
-  readonly: true,
-  validate: false
-});
+const rootStore = new MeshStore(
+  ".graphclient",
+  new FsStoreStorageAdapter({
+    cwd: baseDir,
+    importFn,
+    fileType: "ts",
+  }),
+  {
+    readonly: true,
+    validate: false,
+  },
+);
 
-export const rawServeConfig: YamlConfig.Config['serve'] = undefined as any
+export const rawServeConfig: YamlConfig.Config["serve"] = undefined as any;
 export async function getMeshOptions(): Promise<GetMeshOptions> {
-const pubsub = new PubSub();
-const sourcesStore = rootStore.child('sources');
-const logger = new DefaultLogger("GraphClient");
-const cache = new (MeshCache as any)({
-      ...({} as any),
-      importFn,
-      store: rootStore.child('cache'),
-      pubsub,
-      logger,
-    } as any)
+  const pubsub = new PubSub();
+  const sourcesStore = rootStore.child("sources");
+  const logger = new DefaultLogger("GraphClient");
+  const cache = new (MeshCache as any)({
+    ...({} as any),
+    importFn,
+    store: rootStore.child("cache"),
+    pubsub,
+    logger,
+  } as any);
 
-const sources: MeshResolvedSource[] = [];
-const transforms: MeshTransform[] = [];
-const additionalEnvelopPlugins: MeshPlugin<any>[] = [];
-const hypercertsDevTransforms = [];
-const additionalTypeDefs = [] as any[];
-const hypercertsDevHandler = new GraphqlHandler({
-              name: "hypercerts-dev",
-              config: {"endpoint":"https://api.thegraph.com/subgraphs/name/bitbeckers/hypercerts-dev"},
-              baseDir,
-              cache,
-              pubsub,
-              store: sourcesStore.child("hypercerts-dev"),
-              logger: logger.child("hypercerts-dev"),
-              importFn,
-            });
-sources[0] = {
-          name: 'hypercerts-dev',
-          handler: hypercertsDevHandler,
-          transforms: hypercertsDevTransforms
-        }
-const additionalResolvers = [] as any[]
-const merger = new(BareMerger as any)({
-        cache,
-        pubsub,
-        logger: logger.child('bareMerger'),
-        store: rootStore.child('bareMerger')
-      })
+  const sources: MeshResolvedSource[] = [];
+  const transforms: MeshTransform[] = [];
+  const additionalEnvelopPlugins: MeshPlugin<any>[] = [];
+  const hypercertsDevTransforms = [];
+  const additionalTypeDefs = [] as any[];
+  const hypercertsDevHandler = new GraphqlHandler({
+    name: "hypercerts-dev",
+    config: { endpoint: "https://api.thegraph.com/subgraphs/name/bitbeckers/hypercerts-dev" },
+    baseDir,
+    cache,
+    pubsub,
+    store: sourcesStore.child("hypercerts-dev"),
+    logger: logger.child("hypercerts-dev"),
+    importFn,
+  });
+  sources[0] = {
+    name: "hypercerts-dev",
+    handler: hypercertsDevHandler,
+    transforms: hypercertsDevTransforms,
+  };
+  const additionalResolvers = [] as any[];
+  const merger = new (BareMerger as any)({
+    cache,
+    pubsub,
+    logger: logger.child("bareMerger"),
+    store: rootStore.child("bareMerger"),
+  });
 
   return {
     sources,
@@ -840,44 +955,49 @@ const merger = new(BareMerger as any)({
     additionalEnvelopPlugins,
     get documents() {
       return [
-      {
-        document: ClaimsByOwnerDocument,
-        get rawSDL() {
-          return printWithCache(ClaimsByOwnerDocument);
+        {
+          document: ClaimsByOwnerDocument,
+          get rawSDL() {
+            return printWithCache(ClaimsByOwnerDocument);
+          },
+          location: "ClaimsByOwnerDocument.graphql",
         },
-        location: 'ClaimsByOwnerDocument.graphql'
-      },{
-        document: RecentClaimsDocument,
-        get rawSDL() {
-          return printWithCache(RecentClaimsDocument);
+        {
+          document: RecentClaimsDocument,
+          get rawSDL() {
+            return printWithCache(RecentClaimsDocument);
+          },
+          location: "RecentClaimsDocument.graphql",
         },
-        location: 'RecentClaimsDocument.graphql'
-      },{
-        document: ClaimByIdDocument,
-        get rawSDL() {
-          return printWithCache(ClaimByIdDocument);
+        {
+          document: ClaimByIdDocument,
+          get rawSDL() {
+            return printWithCache(ClaimByIdDocument);
+          },
+          location: "ClaimByIdDocument.graphql",
         },
-        location: 'ClaimByIdDocument.graphql'
-      },{
-        document: ClaimTokensByOwnerDocument,
-        get rawSDL() {
-          return printWithCache(ClaimTokensByOwnerDocument);
+        {
+          document: ClaimTokensByOwnerDocument,
+          get rawSDL() {
+            return printWithCache(ClaimTokensByOwnerDocument);
+          },
+          location: "ClaimTokensByOwnerDocument.graphql",
         },
-        location: 'ClaimTokensByOwnerDocument.graphql'
-      },{
-        document: ClaimTokensByClaimDocument,
-        get rawSDL() {
-          return printWithCache(ClaimTokensByClaimDocument);
+        {
+          document: ClaimTokensByClaimDocument,
+          get rawSDL() {
+            return printWithCache(ClaimTokensByClaimDocument);
+          },
+          location: "ClaimTokensByClaimDocument.graphql",
         },
-        location: 'ClaimTokensByClaimDocument.graphql'
-      },{
-        document: ClaimTokenByIdDocument,
-        get rawSDL() {
-          return printWithCache(ClaimTokenByIdDocument);
+        {
+          document: ClaimTokenByIdDocument,
+          get rawSDL() {
+            return printWithCache(ClaimTokenByIdDocument);
+          },
+          location: "ClaimTokenByIdDocument.graphql",
         },
-        location: 'ClaimTokenByIdDocument.graphql'
-      }
-    ];
+      ];
     },
     fetchFn,
   };
@@ -888,190 +1008,221 @@ export function createBuiltMeshHTTPHandler(): MeshHTTPHandler<MeshContext> {
     baseDir,
     getBuiltMesh: getBuiltGraphClient,
     rawServeConfig: undefined,
-  })
+  });
 }
-
 
 let meshInstance$: Promise<MeshInstance> | undefined;
 
 export function getBuiltGraphClient(): Promise<MeshInstance> {
   if (meshInstance$ == null) {
-    meshInstance$ = getMeshOptions().then(meshOptions => getMesh(meshOptions)).then(mesh => {
-      const id = mesh.pubsub.subscribe('destroy', () => {
-        meshInstance$ = undefined;
-        mesh.pubsub.unsubscribe(id);
+    meshInstance$ = getMeshOptions()
+      .then((meshOptions) => getMesh(meshOptions))
+      .then((mesh) => {
+        const id = mesh.pubsub.subscribe("destroy", () => {
+          meshInstance$ = undefined;
+          mesh.pubsub.unsubscribe(id);
+        });
+        return mesh;
       });
-      return mesh;
-    });
   }
   return meshInstance$;
 }
 
 export const execute: ExecuteMeshFn = (...args) => getBuiltGraphClient().then(({ execute }) => execute(...args));
 
-export const subscribe: SubscribeMeshFn = (...args) => getBuiltGraphClient().then(({ subscribe }) => subscribe(...args));
+export const subscribe: SubscribeMeshFn = (...args) =>
+  getBuiltGraphClient().then(({ subscribe }) => subscribe(...args));
 export function getBuiltGraphSDK<TGlobalContext = any, TOperationContext = any>(globalContext?: TGlobalContext) {
   const sdkRequester$ = getBuiltGraphClient().then(({ sdkRequesterFactory }) => sdkRequesterFactory(globalContext));
-  return getSdk<TOperationContext, TGlobalContext>((...args) => sdkRequester$.then(sdkRequester => sdkRequester(...args)));
+  return getSdk<TOperationContext, TGlobalContext>((...args) =>
+    sdkRequester$.then((sdkRequester) => sdkRequester(...args)),
+  );
 }
 export type ClaimsByOwnerQueryVariables = Exact<{
-  owner?: InputMaybe<Scalars['Bytes']>;
+  owner?: InputMaybe<Scalars["Bytes"]>;
 }>;
 
-
-export type ClaimsByOwnerQuery = { claims: Array<Pick<Claim, 'contract' | 'tokenID' | 'creator' | 'id' | 'owner' | 'totalUnits' | 'uri'>> };
+export type ClaimsByOwnerQuery = {
+  claims: Array<Pick<Claim, "contract" | "tokenID" | "creator" | "id" | "owner" | "totalUnits" | "uri">>;
+};
 
 export type RecentClaimsQueryVariables = Exact<{
-  first?: InputMaybe<Scalars['Int']>;
+  first?: InputMaybe<Scalars["Int"]>;
 }>;
 
-
-export type RecentClaimsQuery = { claims: Array<Pick<Claim, 'contract' | 'tokenID' | 'creator' | 'id' | 'owner' | 'totalUnits' | 'uri'>> };
+export type RecentClaimsQuery = {
+  claims: Array<Pick<Claim, "contract" | "tokenID" | "creator" | "id" | "owner" | "totalUnits" | "uri">>;
+};
 
 export type ClaimByIdQueryVariables = Exact<{
-  id: Scalars['ID'];
+  id: Scalars["ID"];
 }>;
 
-
-export type ClaimByIdQuery = { claim?: Maybe<Pick<Claim, 'contract' | 'tokenID' | 'creator' | 'id' | 'owner' | 'totalUnits' | 'uri'>> };
+export type ClaimByIdQuery = {
+  claim?: Maybe<Pick<Claim, "contract" | "tokenID" | "creator" | "id" | "owner" | "totalUnits" | "uri">>;
+};
 
 export type ClaimTokensByOwnerQueryVariables = Exact<{
-  owner?: InputMaybe<Scalars['Bytes']>;
+  owner?: InputMaybe<Scalars["Bytes"]>;
 }>;
 
-
-export type ClaimTokensByOwnerQuery = { claimTokens: Array<(
-    Pick<ClaimToken, 'id' | 'owner' | 'tokenID' | 'units'>
-    & { claim: Pick<Claim, 'id' | 'creation' | 'uri' | 'totalUnits'> }
-  )> };
+export type ClaimTokensByOwnerQuery = {
+  claimTokens: Array<
+    Pick<ClaimToken, "id" | "owner" | "tokenID" | "units"> & {
+      claim: Pick<Claim, "id" | "creation" | "uri" | "totalUnits">;
+    }
+  >;
+};
 
 export type ClaimTokensByClaimQueryVariables = Exact<{
-  claimId: Scalars['String'];
+  claimId: Scalars["String"];
 }>;
 
-
-export type ClaimTokensByClaimQuery = { claimTokens: Array<Pick<ClaimToken, 'id' | 'owner' | 'tokenID' | 'units'>> };
+export type ClaimTokensByClaimQuery = { claimTokens: Array<Pick<ClaimToken, "id" | "owner" | "tokenID" | "units">> };
 
 export type ClaimTokenByIdQueryVariables = Exact<{
-  claimTokenId: Scalars['ID'];
+  claimTokenId: Scalars["ID"];
 }>;
 
-
-export type ClaimTokenByIdQuery = { claimToken?: Maybe<(
-    Pick<ClaimToken, 'id' | 'owner' | 'tokenID' | 'units'>
-    & { claim: Pick<Claim, 'id' | 'creation' | 'uri' | 'totalUnits'> }
-  )> };
-
+export type ClaimTokenByIdQuery = {
+  claimToken?: Maybe<
+    Pick<ClaimToken, "id" | "owner" | "tokenID" | "units"> & {
+      claim: Pick<Claim, "id" | "creation" | "uri" | "totalUnits">;
+    }
+  >;
+};
 
 export const ClaimsByOwnerDocument = gql`
-    query ClaimsByOwner($owner: Bytes = "") {
-  claims(where: {owner: $owner}) {
-    contract
-    tokenID
-    creator
-    id
-    owner
-    totalUnits
-    uri
+  query ClaimsByOwner($owner: Bytes = "") {
+    claims(where: { owner: $owner }) {
+      contract
+      tokenID
+      creator
+      id
+      owner
+      totalUnits
+      uri
+    }
   }
-}
-    ` as unknown as DocumentNode<ClaimsByOwnerQuery, ClaimsByOwnerQueryVariables>;
+` as unknown as DocumentNode<ClaimsByOwnerQuery, ClaimsByOwnerQueryVariables>;
 export const RecentClaimsDocument = gql`
-    query RecentClaims($first: Int = 10) {
-  claims(orderDirection: desc, orderBy: creation, first: $first) {
-    contract
-    tokenID
-    creator
-    id
-    owner
-    totalUnits
-    uri
+  query RecentClaims($first: Int = 10) {
+    claims(orderDirection: desc, orderBy: creation, first: $first) {
+      contract
+      tokenID
+      creator
+      id
+      owner
+      totalUnits
+      uri
+    }
   }
-}
-    ` as unknown as DocumentNode<RecentClaimsQuery, RecentClaimsQueryVariables>;
+` as unknown as DocumentNode<RecentClaimsQuery, RecentClaimsQueryVariables>;
 export const ClaimByIdDocument = gql`
-    query ClaimById($id: ID!) {
-  claim(id: $id) {
-    contract
-    tokenID
-    creator
-    id
-    owner
-    totalUnits
-    uri
+  query ClaimById($id: ID!) {
+    claim(id: $id) {
+      contract
+      tokenID
+      creator
+      id
+      owner
+      totalUnits
+      uri
+    }
   }
-}
-    ` as unknown as DocumentNode<ClaimByIdQuery, ClaimByIdQueryVariables>;
+` as unknown as DocumentNode<ClaimByIdQuery, ClaimByIdQueryVariables>;
 export const ClaimTokensByOwnerDocument = gql`
-    query ClaimTokensByOwner($owner: Bytes = "") {
-  claimTokens(where: {owner: $owner}, first: 30) {
-    id
-    owner
-    tokenID
-    units
-    claim {
+  query ClaimTokensByOwner($owner: Bytes = "") {
+    claimTokens(where: { owner: $owner }, first: 30) {
       id
-      creation
-      uri
-      totalUnits
+      owner
+      tokenID
+      units
+      claim {
+        id
+        creation
+        uri
+        totalUnits
+      }
     }
   }
-}
-    ` as unknown as DocumentNode<ClaimTokensByOwnerQuery, ClaimTokensByOwnerQueryVariables>;
+` as unknown as DocumentNode<ClaimTokensByOwnerQuery, ClaimTokensByOwnerQueryVariables>;
 export const ClaimTokensByClaimDocument = gql`
-    query ClaimTokensByClaim($claimId: String!) {
-  claimTokens(where: {claim: $claimId}) {
-    id
-    owner
-    tokenID
-    units
-  }
-}
-    ` as unknown as DocumentNode<ClaimTokensByClaimQuery, ClaimTokensByClaimQueryVariables>;
-export const ClaimTokenByIdDocument = gql`
-    query ClaimTokenById($claimTokenId: ID!) {
-  claimToken(id: $claimTokenId) {
-    id
-    owner
-    tokenID
-    units
-    claim {
+  query ClaimTokensByClaim($claimId: String!) {
+    claimTokens(where: { claim: $claimId }) {
       id
-      creation
-      uri
-      totalUnits
+      owner
+      tokenID
+      units
     }
   }
-}
-    ` as unknown as DocumentNode<ClaimTokenByIdQuery, ClaimTokenByIdQueryVariables>;
+` as unknown as DocumentNode<ClaimTokensByClaimQuery, ClaimTokensByClaimQueryVariables>;
+export const ClaimTokenByIdDocument = gql`
+  query ClaimTokenById($claimTokenId: ID!) {
+    claimToken(id: $claimTokenId) {
+      id
+      owner
+      tokenID
+      units
+      claim {
+        id
+        creation
+        uri
+        totalUnits
+      }
+    }
+  }
+` as unknown as DocumentNode<ClaimTokenByIdQuery, ClaimTokenByIdQueryVariables>;
 
-
-
-
-
-
-
-export type Requester<C = {}, E = unknown> = <R, V>(doc: DocumentNode, vars?: V, options?: C) => Promise<R> | AsyncIterable<R>
+export type Requester<C = {}, E = unknown> = <R, V>(
+  doc: DocumentNode,
+  vars?: V,
+  options?: C,
+) => Promise<R> | AsyncIterable<R>;
 export function getSdk<C, E>(requester: Requester<C, E>) {
   return {
     ClaimsByOwner(variables?: ClaimsByOwnerQueryVariables, options?: C): Promise<ClaimsByOwnerQuery> {
-      return requester<ClaimsByOwnerQuery, ClaimsByOwnerQueryVariables>(ClaimsByOwnerDocument, variables, options) as Promise<ClaimsByOwnerQuery>;
+      return requester<ClaimsByOwnerQuery, ClaimsByOwnerQueryVariables>(
+        ClaimsByOwnerDocument,
+        variables,
+        options,
+      ) as Promise<ClaimsByOwnerQuery>;
     },
     RecentClaims(variables?: RecentClaimsQueryVariables, options?: C): Promise<RecentClaimsQuery> {
-      return requester<RecentClaimsQuery, RecentClaimsQueryVariables>(RecentClaimsDocument, variables, options) as Promise<RecentClaimsQuery>;
+      return requester<RecentClaimsQuery, RecentClaimsQueryVariables>(
+        RecentClaimsDocument,
+        variables,
+        options,
+      ) as Promise<RecentClaimsQuery>;
     },
     ClaimById(variables: ClaimByIdQueryVariables, options?: C): Promise<ClaimByIdQuery> {
-      return requester<ClaimByIdQuery, ClaimByIdQueryVariables>(ClaimByIdDocument, variables, options) as Promise<ClaimByIdQuery>;
+      return requester<ClaimByIdQuery, ClaimByIdQueryVariables>(
+        ClaimByIdDocument,
+        variables,
+        options,
+      ) as Promise<ClaimByIdQuery>;
     },
     ClaimTokensByOwner(variables?: ClaimTokensByOwnerQueryVariables, options?: C): Promise<ClaimTokensByOwnerQuery> {
-      return requester<ClaimTokensByOwnerQuery, ClaimTokensByOwnerQueryVariables>(ClaimTokensByOwnerDocument, variables, options) as Promise<ClaimTokensByOwnerQuery>;
+      return requester<ClaimTokensByOwnerQuery, ClaimTokensByOwnerQueryVariables>(
+        ClaimTokensByOwnerDocument,
+        variables,
+        options,
+      ) as Promise<ClaimTokensByOwnerQuery>;
     },
     ClaimTokensByClaim(variables: ClaimTokensByClaimQueryVariables, options?: C): Promise<ClaimTokensByClaimQuery> {
-      return requester<ClaimTokensByClaimQuery, ClaimTokensByClaimQueryVariables>(ClaimTokensByClaimDocument, variables, options) as Promise<ClaimTokensByClaimQuery>;
+      return requester<ClaimTokensByClaimQuery, ClaimTokensByClaimQueryVariables>(
+        ClaimTokensByClaimDocument,
+        variables,
+        options,
+      ) as Promise<ClaimTokensByClaimQuery>;
     },
     ClaimTokenById(variables: ClaimTokenByIdQueryVariables, options?: C): Promise<ClaimTokenByIdQuery> {
-      return requester<ClaimTokenByIdQuery, ClaimTokenByIdQueryVariables>(ClaimTokenByIdDocument, variables, options) as Promise<ClaimTokenByIdQuery>;
-    }
+      return requester<ClaimTokenByIdQuery, ClaimTokenByIdQueryVariables>(
+        ClaimTokenByIdDocument,
+        variables,
+        options,
+      ) as Promise<ClaimTokenByIdQuery>;
+    },
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/sdk/src/.graphclient/schema.graphql
+++ b/sdk/src/.graphclient/schema.graphql
@@ -80,6 +80,14 @@ enum Allowlist_orderBy {
   id
   root
   claim
+  claim__id
+  claim__creation
+  claim__tokenID
+  claim__contract
+  claim__uri
+  claim__creator
+  claim__owner
+  claim__totalUnits
 }
 
 scalar BigDecimal
@@ -195,6 +203,14 @@ enum ClaimToken_orderBy {
   id
   tokenID
   claim
+  claim__id
+  claim__creation
+  claim__tokenID
+  claim__contract
+  claim__uri
+  claim__creator
+  claim__owner
+  claim__totalUnits
   owner
   units
 }

--- a/sdk/src/.graphclient/sources/hypercerts-dev/introspectionSchema.ts
+++ b/sdk/src/.graphclient/sources/hypercerts-dev/introspectionSchema.ts
@@ -1,6202 +1,6345 @@
 // @ts-nocheck
-import { buildASTSchema } from 'graphql';
+import { buildASTSchema } from "graphql";
 
 const schemaAST = {
-  "kind": "Document",
-  "definitions": [
+  kind: "Document",
+  definitions: [
     {
-      "kind": "SchemaDefinition",
-      "operationTypes": [
+      kind: "SchemaDefinition",
+      operationTypes: [
         {
-          "kind": "OperationTypeDefinition",
-          "operation": "query",
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Query"
-            }
-          }
+          kind: "OperationTypeDefinition",
+          operation: "query",
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Query",
+            },
+          },
         },
         {
-          "kind": "OperationTypeDefinition",
-          "operation": "subscription",
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Subscription"
-            }
-          }
-        }
+          kind: "OperationTypeDefinition",
+          operation: "subscription",
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Subscription",
+            },
+          },
+        },
       ],
-      "directives": []
+      directives: [],
     },
     {
-      "kind": "DirectiveDefinition",
-      "description": {
-        "kind": "StringValue",
-        "value": "Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive."
+      kind: "DirectiveDefinition",
+      description: {
+        kind: "StringValue",
+        value:
+          "Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive.",
       },
-      "name": {
-        "kind": "Name",
-        "value": "entity"
+      name: {
+        kind: "Name",
+        value: "entity",
       },
-      "arguments": [],
-      "repeatable": false,
-      "locations": [
+      arguments: [],
+      repeatable: false,
+      locations: [
         {
-          "kind": "Name",
-          "value": "OBJECT"
-        }
-      ]
-    },
-    {
-      "kind": "DirectiveDefinition",
-      "description": {
-        "kind": "StringValue",
-        "value": "Defined a Subgraph ID for an object type"
-      },
-      "name": {
-        "kind": "Name",
-        "value": "subgraphId"
-      },
-      "arguments": [
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id"
-          },
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "String"
-              }
-            }
-          },
-          "directives": []
-        }
+          kind: "Name",
+          value: "OBJECT",
+        },
       ],
-      "repeatable": false,
-      "locations": [
-        {
-          "kind": "Name",
-          "value": "OBJECT"
-        }
-      ]
     },
     {
-      "kind": "DirectiveDefinition",
-      "description": {
-        "kind": "StringValue",
-        "value": "creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API."
+      kind: "DirectiveDefinition",
+      description: {
+        kind: "StringValue",
+        value: "Defined a Subgraph ID for an object type",
       },
-      "name": {
-        "kind": "Name",
-        "value": "derivedFrom"
+      name: {
+        kind: "Name",
+        value: "subgraphId",
       },
-      "arguments": [
+      arguments: [
         {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "field"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id",
           },
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "String"
-              }
-            }
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "String",
+              },
+            },
           },
-          "directives": []
-        }
+          directives: [],
+        },
       ],
-      "repeatable": false,
-      "locations": [
+      repeatable: false,
+      locations: [
         {
-          "kind": "Name",
-          "value": "FIELD_DEFINITION"
-        }
-      ]
-    },
-    {
-      "kind": "ObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "Allowlist"
-      },
-      "fields": [
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "String"
-              }
-            }
-          },
-          "directives": []
+          kind: "Name",
+          value: "OBJECT",
         },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Bytes"
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Claim"
-              }
-            }
-          },
-          "directives": []
-        }
       ],
-      "interfaces": [],
-      "directives": []
     },
     {
-      "kind": "InputObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "Allowlist_filter"
+      kind: "DirectiveDefinition",
+      description: {
+        kind: "StringValue",
+        value:
+          "creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.",
       },
-      "fields": [
+      name: {
+        kind: "Name",
+        value: "derivedFrom",
+      },
+      arguments: [
         {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "field",
           },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "String",
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Bytes"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Bytes"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Claim_filter"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "Filter for the block changed event.",
-            "block": true
-          },
-          "name": {
-            "kind": "Name",
-            "value": "_change_block"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BlockChangedFilter"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "and"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Allowlist_filter"
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "or"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Allowlist_filter"
-              }
-            }
-          },
-          "directives": []
-        }
       ],
-      "directives": []
-    },
-    {
-      "kind": "EnumTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "Allowlist_orderBy"
-      },
-      "values": [
+      repeatable: false,
+      locations: [
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id"
-          },
-          "directives": []
+          kind: "Name",
+          value: "FIELD_DEFINITION",
         },
-        {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "root"
-          },
-          "directives": []
-        },
-        {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim"
-          },
-          "directives": []
-        }
       ],
-      "directives": []
     },
     {
-      "kind": "ScalarTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "BigDecimal"
+      kind: "ObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "Allowlist",
       },
-      "directives": []
-    },
-    {
-      "kind": "ScalarTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "BigInt"
-      },
-      "directives": []
-    },
-    {
-      "kind": "InputObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "BlockChangedFilter"
-      },
-      "fields": [
+      fields: [
         {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "number_gte"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "id",
           },
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Int"
-              }
-            }
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "String",
+              },
+            },
           },
-          "directives": []
-        }
+          directives: [],
+        },
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "root",
+          },
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Bytes",
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "claim",
+          },
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Claim",
+              },
+            },
+          },
+          directives: [],
+        },
       ],
-      "directives": []
+      interfaces: [],
+      directives: [],
     },
     {
-      "kind": "InputObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "Block_height"
+      kind: "InputObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "Allowlist_filter",
       },
-      "fields": [
+      fields: [
         {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "hash"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id",
           },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "number"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not",
           },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Int"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "number_gte"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_gt",
           },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Int"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
           },
-          "directives": []
-        }
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Bytes",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Bytes",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Claim_filter",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          description: {
+            kind: "StringValue",
+            value: "Filter for the block changed event.",
+            block: true,
+          },
+          name: {
+            kind: "Name",
+            value: "_change_block",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BlockChangedFilter",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "and",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Allowlist_filter",
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "or",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Allowlist_filter",
+              },
+            },
+          },
+          directives: [],
+        },
       ],
-      "directives": []
+      directives: [],
     },
     {
-      "kind": "ScalarTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "Bytes"
+      kind: "EnumTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "Allowlist_orderBy",
       },
-      "directives": []
-    },
-    {
-      "kind": "ObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "Claim"
-      },
-      "fields": [
+      values: [
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id"
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "String"
-              }
-            }
-          },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creation"
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "root",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "BigInt"
-              }
-            }
-          },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID"
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "BigInt"
-              }
-            }
-          },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract"
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__id",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "String"
-              }
-            }
-          },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri"
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__creation",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator"
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__tokenID",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner"
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__contract",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "totalUnits"
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__uri",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__creator",
           },
-          "directives": []
-        }
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__owner",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__totalUnits",
+          },
+          directives: [],
+        },
       ],
-      "interfaces": [],
-      "directives": []
+      directives: [],
     },
     {
-      "kind": "ObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "ClaimToken"
+      kind: "ScalarTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "BigDecimal",
       },
-      "fields": [
+      directives: [],
+    },
+    {
+      kind: "ScalarTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "BigInt",
+      },
+      directives: [],
+    },
+    {
+      kind: "InputObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "BlockChangedFilter",
+      },
+      fields: [
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "number_gte",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "String"
-              }
-            }
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Int",
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "BigInt"
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Claim"
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Bytes"
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "units"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "BigInt"
-              }
-            }
-          },
-          "directives": []
-        }
       ],
-      "interfaces": [],
-      "directives": []
+      directives: [],
     },
     {
-      "kind": "InputObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "ClaimToken_filter"
+      kind: "InputObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "Block_height",
       },
-      "fields": [
+      fields: [
         {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "hash",
           },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "number",
           },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Int",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_gt"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "number_gte",
           },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Int",
+            },
           },
-          "directives": []
+          directives: [],
         },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "BigInt"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "BigInt"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_not_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim_"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Claim_filter"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Bytes"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Bytes"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "units"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "units_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "units_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "units_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "units_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "units_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "units_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "BigInt"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "units_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "BigInt"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "Filter for the block changed event.",
-            "block": true
-          },
-          "name": {
-            "kind": "Name",
-            "value": "_change_block"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BlockChangedFilter"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "and"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "ClaimToken_filter"
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "or"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "ClaimToken_filter"
-              }
-            }
-          },
-          "directives": []
-        }
       ],
-      "directives": []
+      directives: [],
     },
     {
-      "kind": "EnumTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "ClaimToken_orderBy"
+      kind: "ScalarTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "Bytes",
       },
-      "values": [
+      directives: [],
+    },
+    {
+      kind: "ObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "Claim",
+      },
+      fields: [
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "id",
           },
-          "directives": []
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "String",
+              },
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "creation",
           },
-          "directives": []
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "BigInt",
+              },
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID",
           },
-          "directives": []
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "BigInt",
+              },
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "contract",
           },
-          "directives": []
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "String",
+              },
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "units"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "uri",
           },
-          "directives": []
-        }
+          arguments: [],
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "creator",
+          },
+          arguments: [],
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "owner",
+          },
+          arguments: [],
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "totalUnits",
+          },
+          arguments: [],
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
       ],
-      "directives": []
+      interfaces: [],
+      directives: [],
     },
     {
-      "kind": "InputObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "Claim_filter"
+      kind: "ObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "ClaimToken",
       },
-      "fields": [
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id_not_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creation"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creation_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creation_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creation_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creation_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creation_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creation_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "BigInt"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creation_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "BigInt"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "BigInt"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "BigInt"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_not_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_not_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_not_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_not_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract_not_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_not_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_not_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_not_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_not_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri_not_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Bytes"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Bytes"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Bytes"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Bytes"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "totalUnits"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "totalUnits_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "totalUnits_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "totalUnits_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "totalUnits_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "totalUnits_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BigInt"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "totalUnits_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "BigInt"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "totalUnits_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "BigInt"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "Filter for the block changed event.",
-            "block": true
-          },
-          "name": {
-            "kind": "Name",
-            "value": "_change_block"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "BlockChangedFilter"
-            }
-          },
-          "directives": []
+      fields: [
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "id",
+          },
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "String",
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID",
+          },
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "BigInt",
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "claim",
+          },
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Claim",
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "owner",
+          },
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Bytes",
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "units",
+          },
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "BigInt",
+              },
+            },
+          },
+          directives: [],
         },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "and"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Claim_filter"
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "or"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Claim_filter"
-              }
-            }
-          },
-          "directives": []
-        }
       ],
-      "directives": []
+      interfaces: [],
+      directives: [],
     },
     {
-      "kind": "EnumTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "Claim_orderBy"
+      kind: "InputObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "ClaimToken_filter",
       },
-      "values": [
+      fields: [
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "id"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id",
           },
-          "directives": []
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creation"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not",
           },
-          "directives": []
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "tokenID"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_gt",
           },
-          "directives": []
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "contract"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_lt",
           },
-          "directives": []
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "uri"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_gte",
           },
-          "directives": []
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "creator"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_lte",
           },
-          "directives": []
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "owner"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_in",
           },
-          "directives": []
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "totalUnits"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_in",
           },
-          "directives": []
-        }
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "BigInt",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "BigInt",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_not_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim_",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Claim_filter",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Bytes",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Bytes",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "units",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "units_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "units_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "units_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "units_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "units_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "units_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "BigInt",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "units_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "BigInt",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          description: {
+            kind: "StringValue",
+            value: "Filter for the block changed event.",
+            block: true,
+          },
+          name: {
+            kind: "Name",
+            value: "_change_block",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BlockChangedFilter",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "and",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "ClaimToken_filter",
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "or",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "ClaimToken_filter",
+              },
+            },
+          },
+          directives: [],
+        },
       ],
-      "directives": []
+      directives: [],
     },
     {
-      "kind": "EnumTypeDefinition",
-      "description": {
-        "kind": "StringValue",
-        "value": "Defines the order direction, either ascending or descending",
-        "block": true
+      kind: "EnumTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "ClaimToken_orderBy",
       },
-      "name": {
-        "kind": "Name",
-        "value": "OrderDirection"
-      },
-      "values": [
+      values: [
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "asc"
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id",
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "desc"
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID",
           },
-          "directives": []
-        }
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__id",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__creation",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__tokenID",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__contract",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__uri",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__creator",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__owner",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "claim__totalUnits",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "units",
+          },
+          directives: [],
+        },
       ],
-      "directives": []
+      directives: [],
     },
     {
-      "kind": "ObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "Query"
+      kind: "InputObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "Claim_filter",
       },
-      "fields": [
+      fields: [
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "allowlist"
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id",
           },
-          "arguments": [
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id_not_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creation",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creation_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creation_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creation_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creation_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creation_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creation_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "BigInt",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creation_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "BigInt",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "BigInt",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "BigInt",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_not_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_not_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_not_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_not_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract_not_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "String",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_not_contains_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_not_starts_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_not_starts_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_not_ends_with",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri_not_ends_with_nocase",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "String",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Bytes",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Bytes",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Bytes",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Bytes",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner_not_contains",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "totalUnits",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "totalUnits_not",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "totalUnits_gt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "totalUnits_lt",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "totalUnits_gte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "totalUnits_lte",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BigInt",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "totalUnits_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "BigInt",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "totalUnits_not_in",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NonNullType",
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "BigInt",
+                },
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          description: {
+            kind: "StringValue",
+            value: "Filter for the block changed event.",
+            block: true,
+          },
+          name: {
+            kind: "Name",
+            value: "_change_block",
+          },
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "BlockChangedFilter",
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "and",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Claim_filter",
+              },
+            },
+          },
+          directives: [],
+        },
+        {
+          kind: "InputValueDefinition",
+          name: {
+            kind: "Name",
+            value: "or",
+          },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Claim_filter",
+              },
+            },
+          },
+          directives: [],
+        },
+      ],
+      directives: [],
+    },
+    {
+      kind: "EnumTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "Claim_orderBy",
+      },
+      values: [
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "id",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creation",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "tokenID",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "contract",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "uri",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "creator",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "owner",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "totalUnits",
+          },
+          directives: [],
+        },
+      ],
+      directives: [],
+    },
+    {
+      kind: "EnumTypeDefinition",
+      description: {
+        kind: "StringValue",
+        value: "Defines the order direction, either ascending or descending",
+        block: true,
+      },
+      name: {
+        kind: "Name",
+        value: "OrderDirection",
+      },
+      values: [
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "asc",
+          },
+          directives: [],
+        },
+        {
+          kind: "EnumValueDefinition",
+          name: {
+            kind: "Name",
+            value: "desc",
+          },
+          directives: [],
+        },
+      ],
+      directives: [],
+    },
+    {
+      kind: "ObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "Query",
+      },
+      fields: [
+        {
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "allowlist",
+          },
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "id"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "id",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "ID"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "ID",
+                  },
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Allowlist"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Allowlist",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "allowlists"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "allowlists",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "skip"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "skip",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "0"
+              defaultValue: {
+                kind: "IntValue",
+                value: "0",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "first"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "first",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "100"
+              defaultValue: {
+                kind: "IntValue",
+                value: "100",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderBy"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderBy",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Allowlist_orderBy"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Allowlist_orderBy",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderDirection"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderDirection",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "OrderDirection"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "OrderDirection",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "where"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "where",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Allowlist_filter"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Allowlist_filter",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "ListType",
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "Allowlist"
-                  }
-                }
-              }
-            }
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "Allowlist",
+                  },
+                },
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "claim",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "id"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "id",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "ID"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "ID",
+                  },
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Claim"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Claim",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claims"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "claims",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "skip"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "skip",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "0"
+              defaultValue: {
+                kind: "IntValue",
+                value: "0",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "first"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "first",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "100"
+              defaultValue: {
+                kind: "IntValue",
+                value: "100",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderBy"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderBy",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Claim_orderBy"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Claim_orderBy",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderDirection"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderDirection",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "OrderDirection"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "OrderDirection",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "where"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "where",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Claim_filter"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Claim_filter",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "ListType",
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "Claim"
-                  }
-                }
-              }
-            }
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "Claim",
+                  },
+                },
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claimToken"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "claimToken",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "id"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "id",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "ID"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "ID",
+                  },
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "ClaimToken"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "ClaimToken",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claimTokens"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "claimTokens",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "skip"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "skip",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "0"
+              defaultValue: {
+                kind: "IntValue",
+                value: "0",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "first"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "first",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "100"
+              defaultValue: {
+                kind: "IntValue",
+                value: "100",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderBy"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderBy",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "ClaimToken_orderBy"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "ClaimToken_orderBy",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderDirection"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderDirection",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "OrderDirection"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "OrderDirection",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "where"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "where",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "ClaimToken_filter"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "ClaimToken_filter",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "ListType",
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "ClaimToken"
-                  }
-                }
-              }
-            }
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "ClaimToken",
+                  },
+                },
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "Access to subgraph metadata",
-            "block": true
+          kind: "FieldDefinition",
+          description: {
+            kind: "StringValue",
+            value: "Access to subgraph metadata",
+            block: true,
           },
-          "name": {
-            "kind": "Name",
-            "value": "_meta"
+          name: {
+            kind: "Name",
+            value: "_meta",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "_Meta_"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "_Meta_",
+            },
           },
-          "directives": []
-        }
+          directives: [],
+        },
       ],
-      "interfaces": [],
-      "directives": []
+      interfaces: [],
+      directives: [],
     },
     {
-      "kind": "ObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "Subscription"
+      kind: "ObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "Subscription",
       },
-      "fields": [
+      fields: [
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "allowlist"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "allowlist",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "id"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "id",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "ID"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "ID",
+                  },
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Allowlist"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Allowlist",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "allowlists"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "allowlists",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "skip"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "skip",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "0"
+              defaultValue: {
+                kind: "IntValue",
+                value: "0",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "first"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "first",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "100"
+              defaultValue: {
+                kind: "IntValue",
+                value: "100",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderBy"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderBy",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Allowlist_orderBy"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Allowlist_orderBy",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderDirection"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderDirection",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "OrderDirection"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "OrderDirection",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "where"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "where",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Allowlist_filter"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Allowlist_filter",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "ListType",
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "Allowlist"
-                  }
-                }
-              }
-            }
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "Allowlist",
+                  },
+                },
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claim"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "claim",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "id"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "id",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "ID"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "ID",
+                  },
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Claim"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Claim",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claims"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "claims",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "skip"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "skip",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "0"
+              defaultValue: {
+                kind: "IntValue",
+                value: "0",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "first"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "first",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "100"
+              defaultValue: {
+                kind: "IntValue",
+                value: "100",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderBy"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderBy",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Claim_orderBy"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Claim_orderBy",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderDirection"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderDirection",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "OrderDirection"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "OrderDirection",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "where"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "where",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Claim_filter"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Claim_filter",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "ListType",
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "Claim"
-                  }
-                }
-              }
-            }
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "Claim",
+                  },
+                },
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claimToken"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "claimToken",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "id"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "id",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "ID"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "ID",
+                  },
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "ClaimToken"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "ClaimToken",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "claimTokens"
+          kind: "FieldDefinition",
+          name: {
+            kind: "Name",
+            value: "claimTokens",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "skip"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "skip",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "0"
+              defaultValue: {
+                kind: "IntValue",
+                value: "0",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "first"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "first",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Int"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Int",
+                },
               },
-              "defaultValue": {
-                "kind": "IntValue",
-                "value": "100"
+              defaultValue: {
+                kind: "IntValue",
+                value: "100",
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderBy"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderBy",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "ClaimToken_orderBy"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "ClaimToken_orderBy",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "orderDirection"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "orderDirection",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "OrderDirection"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "OrderDirection",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "where"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "where",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "ClaimToken_filter"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "ClaimToken_filter",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value:
+                  "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
+              directives: [],
             },
             {
-              "kind": "InputValueDefinition",
-              "description": {
-                "kind": "StringValue",
-                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
-                "block": true
+              kind: "InputValueDefinition",
+              description: {
+                kind: "StringValue",
+                value: "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                block: true,
               },
-              "name": {
-                "kind": "Name",
-                "value": "subgraphError"
+              name: {
+                kind: "Name",
+                value: "subgraphError",
               },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "_SubgraphErrorPolicy_"
-                  }
-                }
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "_SubgraphErrorPolicy_",
+                  },
+                },
               },
-              "defaultValue": {
-                "kind": "EnumValue",
-                "value": "deny"
+              defaultValue: {
+                kind: "EnumValue",
+                value: "deny",
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "ListType",
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "ClaimToken"
-                  }
-                }
-              }
-            }
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: {
+                kind: "NonNullType",
+                type: {
+                  kind: "NamedType",
+                  name: {
+                    kind: "Name",
+                    value: "ClaimToken",
+                  },
+                },
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "Access to subgraph metadata",
-            "block": true
+          kind: "FieldDefinition",
+          description: {
+            kind: "StringValue",
+            value: "Access to subgraph metadata",
+            block: true,
           },
-          "name": {
-            "kind": "Name",
-            "value": "_meta"
+          name: {
+            kind: "Name",
+            value: "_meta",
           },
-          "arguments": [
+          arguments: [
             {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "block"
+              kind: "InputValueDefinition",
+              name: {
+                kind: "Name",
+                value: "block",
               },
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "Block_height"
-                }
+              type: {
+                kind: "NamedType",
+                name: {
+                  kind: "Name",
+                  value: "Block_height",
+                },
               },
-              "directives": []
-            }
+              directives: [],
+            },
           ],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "_Meta_"
-            }
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "_Meta_",
+            },
           },
-          "directives": []
-        }
+          directives: [],
+        },
       ],
-      "interfaces": [],
-      "directives": []
+      interfaces: [],
+      directives: [],
     },
     {
-      "kind": "ObjectTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "_Block_"
+      kind: "ObjectTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "_Block_",
       },
-      "fields": [
+      fields: [
         {
-          "kind": "FieldDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "The hash of the block",
-            "block": true
+          kind: "FieldDefinition",
+          description: {
+            kind: "StringValue",
+            value: "The hash of the block",
+            block: true,
           },
-          "name": {
-            "kind": "Name",
-            "value": "hash"
+          name: {
+            kind: "Name",
+            value: "hash",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Bytes"
-            }
+          arguments: [],
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Bytes",
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "The block number",
-            "block": true
+          kind: "FieldDefinition",
+          description: {
+            kind: "StringValue",
+            value: "The block number",
+            block: true,
           },
-          "name": {
-            "kind": "Name",
-            "value": "number"
+          name: {
+            kind: "Name",
+            value: "number",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Int"
-              }
-            }
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Int",
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "Integer representation of the timestamp stored in blocks for the chain",
-            "block": true
+          kind: "FieldDefinition",
+          description: {
+            kind: "StringValue",
+            value: "Integer representation of the timestamp stored in blocks for the chain",
+            block: true,
           },
-          "name": {
-            "kind": "Name",
-            "value": "timestamp"
+          name: {
+            kind: "Name",
+            value: "timestamp",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "Int"
-            }
+          arguments: [],
+          type: {
+            kind: "NamedType",
+            name: {
+              kind: "Name",
+              value: "Int",
+            },
           },
-          "directives": []
-        }
+          directives: [],
+        },
       ],
-      "interfaces": [],
-      "directives": []
+      interfaces: [],
+      directives: [],
     },
     {
-      "kind": "ObjectTypeDefinition",
-      "description": {
-        "kind": "StringValue",
-        "value": "The type for the top-level _meta field",
-        "block": true
+      kind: "ObjectTypeDefinition",
+      description: {
+        kind: "StringValue",
+        value: "The type for the top-level _meta field",
+        block: true,
       },
-      "name": {
-        "kind": "Name",
-        "value": "_Meta_"
+      name: {
+        kind: "Name",
+        value: "_Meta_",
       },
-      "fields": [
+      fields: [
         {
-          "kind": "FieldDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "Information about a specific subgraph block. The hash of the block\nwill be null if the _meta field has a block constraint that asks for\na block number. It will be filled if the _meta field has no block constraint\nand therefore asks for the latest  block\n",
-            "block": true
+          kind: "FieldDefinition",
+          description: {
+            kind: "StringValue",
+            value:
+              "Information about a specific subgraph block. The hash of the block\nwill be null if the _meta field has a block constraint that asks for\na block number. It will be filled if the _meta field has no block constraint\nand therefore asks for the latest  block\n",
+            block: true,
           },
-          "name": {
-            "kind": "Name",
-            "value": "block"
+          name: {
+            kind: "Name",
+            value: "block",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "_Block_"
-              }
-            }
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "_Block_",
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "The deployment ID",
-            "block": true
+          kind: "FieldDefinition",
+          description: {
+            kind: "StringValue",
+            value: "The deployment ID",
+            block: true,
           },
-          "name": {
-            "kind": "Name",
-            "value": "deployment"
+          name: {
+            kind: "Name",
+            value: "deployment",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "String"
-              }
-            }
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "String",
+              },
+            },
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "FieldDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "If `true`, the subgraph encountered indexing errors at some past block",
-            "block": true
+          kind: "FieldDefinition",
+          description: {
+            kind: "StringValue",
+            value: "If `true`, the subgraph encountered indexing errors at some past block",
+            block: true,
           },
-          "name": {
-            "kind": "Name",
-            "value": "hasIndexingErrors"
+          name: {
+            kind: "Name",
+            value: "hasIndexingErrors",
           },
-          "arguments": [],
-          "type": {
-            "kind": "NonNullType",
-            "type": {
-              "kind": "NamedType",
-              "name": {
-                "kind": "Name",
-                "value": "Boolean"
-              }
-            }
+          arguments: [],
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "NamedType",
+              name: {
+                kind: "Name",
+                value: "Boolean",
+              },
+            },
           },
-          "directives": []
-        }
+          directives: [],
+        },
       ],
-      "interfaces": [],
-      "directives": []
+      interfaces: [],
+      directives: [],
     },
     {
-      "kind": "EnumTypeDefinition",
-      "name": {
-        "kind": "Name",
-        "value": "_SubgraphErrorPolicy_"
+      kind: "EnumTypeDefinition",
+      name: {
+        kind: "Name",
+        value: "_SubgraphErrorPolicy_",
       },
-      "values": [
+      values: [
         {
-          "kind": "EnumValueDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "Data will be returned even if the subgraph has indexing errors",
-            "block": true
+          kind: "EnumValueDefinition",
+          description: {
+            kind: "StringValue",
+            value: "Data will be returned even if the subgraph has indexing errors",
+            block: true,
           },
-          "name": {
-            "kind": "Name",
-            "value": "allow"
+          name: {
+            kind: "Name",
+            value: "allow",
           },
-          "directives": []
+          directives: [],
         },
         {
-          "kind": "EnumValueDefinition",
-          "description": {
-            "kind": "StringValue",
-            "value": "If the subgraph has indexing errors, data will be omitted. The default.",
-            "block": true
+          kind: "EnumValueDefinition",
+          description: {
+            kind: "StringValue",
+            value: "If the subgraph has indexing errors, data will be omitted. The default.",
+            block: true,
           },
-          "name": {
-            "kind": "Name",
-            "value": "deny"
+          name: {
+            kind: "Name",
+            value: "deny",
           },
-          "directives": []
-        }
+          directives: [],
+        },
       ],
-      "directives": []
-    }
-  ]
+      directives: [],
+    },
+  ],
 };
 
 export default buildASTSchema(schemaAST, {
   assumeValid: true,
-  assumeValidSDL: true
+  assumeValidSDL: true,
 });

--- a/sdk/src/.graphclient/sources/hypercerts-dev/schema.graphql
+++ b/sdk/src/.graphclient/sources/hypercerts-dev/schema.graphql
@@ -80,6 +80,14 @@ enum Allowlist_orderBy {
   id
   root
   claim
+  claim__id
+  claim__creation
+  claim__tokenID
+  claim__contract
+  claim__uri
+  claim__creator
+  claim__owner
+  claim__totalUnits
 }
 
 scalar BigDecimal
@@ -195,6 +203,14 @@ enum ClaimToken_orderBy {
   id
   tokenID
   claim
+  claim__id
+  claim__creation
+  claim__tokenID
+  claim__contract
+  claim__uri
+  claim__creator
+  claim__owner
+  claim__totalUnits
   owner
   units
 }

--- a/sdk/src/.graphclient/sources/hypercerts-dev/types.ts
+++ b/sdk/src/.graphclient/sources/hypercerts-dev/types.ts
@@ -1,542 +1,531 @@
 // @ts-nocheck
 
-import { InContextSdkMethod } from '@graphql-mesh/types';
-import { MeshContext } from '@graphql-mesh/runtime';
+import { InContextSdkMethod } from "@graphql-mesh/types";
+import { MeshContext } from "@graphql-mesh/runtime";
 
 export namespace HypercertsDevTypes {
   export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-/** All built-in and custom scalars, mapped to their actual values */
-export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  BigDecimal: any;
-  BigInt: any;
-  Bytes: any;
-};
+  export type InputMaybe<T> = Maybe<T>;
+  export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+  export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+  export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+  /** All built-in and custom scalars, mapped to their actual values */
+  export type Scalars = {
+    ID: string;
+    String: string;
+    Boolean: boolean;
+    Int: number;
+    Float: number;
+    BigDecimal: any;
+    BigInt: any;
+    Bytes: any;
+  };
 
-export type Allowlist = {
-  id: Scalars['String'];
-  root: Scalars['Bytes'];
-  claim: Claim;
-};
+  export type Allowlist = {
+    id: Scalars["String"];
+    root: Scalars["Bytes"];
+    claim: Claim;
+  };
 
-export type Allowlist_filter = {
-  id?: InputMaybe<Scalars['String']>;
-  id_not?: InputMaybe<Scalars['String']>;
-  id_gt?: InputMaybe<Scalars['String']>;
-  id_lt?: InputMaybe<Scalars['String']>;
-  id_gte?: InputMaybe<Scalars['String']>;
-  id_lte?: InputMaybe<Scalars['String']>;
-  id_in?: InputMaybe<Array<Scalars['String']>>;
-  id_not_in?: InputMaybe<Array<Scalars['String']>>;
-  id_contains?: InputMaybe<Scalars['String']>;
-  id_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_not_contains?: InputMaybe<Scalars['String']>;
-  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_starts_with?: InputMaybe<Scalars['String']>;
-  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_starts_with?: InputMaybe<Scalars['String']>;
-  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_ends_with?: InputMaybe<Scalars['String']>;
-  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_ends_with?: InputMaybe<Scalars['String']>;
-  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  root?: InputMaybe<Scalars['Bytes']>;
-  root_not?: InputMaybe<Scalars['Bytes']>;
-  root_gt?: InputMaybe<Scalars['Bytes']>;
-  root_lt?: InputMaybe<Scalars['Bytes']>;
-  root_gte?: InputMaybe<Scalars['Bytes']>;
-  root_lte?: InputMaybe<Scalars['Bytes']>;
-  root_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  root_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  root_contains?: InputMaybe<Scalars['Bytes']>;
-  root_not_contains?: InputMaybe<Scalars['Bytes']>;
-  claim?: InputMaybe<Scalars['String']>;
-  claim_not?: InputMaybe<Scalars['String']>;
-  claim_gt?: InputMaybe<Scalars['String']>;
-  claim_lt?: InputMaybe<Scalars['String']>;
-  claim_gte?: InputMaybe<Scalars['String']>;
-  claim_lte?: InputMaybe<Scalars['String']>;
-  claim_in?: InputMaybe<Array<Scalars['String']>>;
-  claim_not_in?: InputMaybe<Array<Scalars['String']>>;
-  claim_contains?: InputMaybe<Scalars['String']>;
-  claim_contains_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_contains?: InputMaybe<Scalars['String']>;
-  claim_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  claim_starts_with?: InputMaybe<Scalars['String']>;
-  claim_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_starts_with?: InputMaybe<Scalars['String']>;
-  claim_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_ends_with?: InputMaybe<Scalars['String']>;
-  claim_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_ends_with?: InputMaybe<Scalars['String']>;
-  claim_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_?: InputMaybe<Claim_filter>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Allowlist_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Allowlist_filter>>>;
-};
+  export type Allowlist_filter = {
+    id?: InputMaybe<Scalars["String"]>;
+    id_not?: InputMaybe<Scalars["String"]>;
+    id_gt?: InputMaybe<Scalars["String"]>;
+    id_lt?: InputMaybe<Scalars["String"]>;
+    id_gte?: InputMaybe<Scalars["String"]>;
+    id_lte?: InputMaybe<Scalars["String"]>;
+    id_in?: InputMaybe<Array<Scalars["String"]>>;
+    id_not_in?: InputMaybe<Array<Scalars["String"]>>;
+    id_contains?: InputMaybe<Scalars["String"]>;
+    id_contains_nocase?: InputMaybe<Scalars["String"]>;
+    id_not_contains?: InputMaybe<Scalars["String"]>;
+    id_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+    id_starts_with?: InputMaybe<Scalars["String"]>;
+    id_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    id_not_starts_with?: InputMaybe<Scalars["String"]>;
+    id_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    id_ends_with?: InputMaybe<Scalars["String"]>;
+    id_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    id_not_ends_with?: InputMaybe<Scalars["String"]>;
+    id_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    root?: InputMaybe<Scalars["Bytes"]>;
+    root_not?: InputMaybe<Scalars["Bytes"]>;
+    root_gt?: InputMaybe<Scalars["Bytes"]>;
+    root_lt?: InputMaybe<Scalars["Bytes"]>;
+    root_gte?: InputMaybe<Scalars["Bytes"]>;
+    root_lte?: InputMaybe<Scalars["Bytes"]>;
+    root_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+    root_not_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+    root_contains?: InputMaybe<Scalars["Bytes"]>;
+    root_not_contains?: InputMaybe<Scalars["Bytes"]>;
+    claim?: InputMaybe<Scalars["String"]>;
+    claim_not?: InputMaybe<Scalars["String"]>;
+    claim_gt?: InputMaybe<Scalars["String"]>;
+    claim_lt?: InputMaybe<Scalars["String"]>;
+    claim_gte?: InputMaybe<Scalars["String"]>;
+    claim_lte?: InputMaybe<Scalars["String"]>;
+    claim_in?: InputMaybe<Array<Scalars["String"]>>;
+    claim_not_in?: InputMaybe<Array<Scalars["String"]>>;
+    claim_contains?: InputMaybe<Scalars["String"]>;
+    claim_contains_nocase?: InputMaybe<Scalars["String"]>;
+    claim_not_contains?: InputMaybe<Scalars["String"]>;
+    claim_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+    claim_starts_with?: InputMaybe<Scalars["String"]>;
+    claim_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    claim_not_starts_with?: InputMaybe<Scalars["String"]>;
+    claim_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    claim_ends_with?: InputMaybe<Scalars["String"]>;
+    claim_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    claim_not_ends_with?: InputMaybe<Scalars["String"]>;
+    claim_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    claim_?: InputMaybe<Claim_filter>;
+    /** Filter for the block changed event. */
+    _change_block?: InputMaybe<BlockChangedFilter>;
+    and?: InputMaybe<Array<InputMaybe<Allowlist_filter>>>;
+    or?: InputMaybe<Array<InputMaybe<Allowlist_filter>>>;
+  };
 
-export type Allowlist_orderBy =
-  | 'id'
-  | 'root'
-  | 'claim';
+  export type Allowlist_orderBy =
+    | "id"
+    | "root"
+    | "claim"
+    | "claim__id"
+    | "claim__creation"
+    | "claim__tokenID"
+    | "claim__contract"
+    | "claim__uri"
+    | "claim__creator"
+    | "claim__owner"
+    | "claim__totalUnits";
 
-export type BlockChangedFilter = {
-  number_gte: Scalars['Int'];
-};
+  export type BlockChangedFilter = {
+    number_gte: Scalars["Int"];
+  };
 
-export type Block_height = {
-  hash?: InputMaybe<Scalars['Bytes']>;
-  number?: InputMaybe<Scalars['Int']>;
-  number_gte?: InputMaybe<Scalars['Int']>;
-};
+  export type Block_height = {
+    hash?: InputMaybe<Scalars["Bytes"]>;
+    number?: InputMaybe<Scalars["Int"]>;
+    number_gte?: InputMaybe<Scalars["Int"]>;
+  };
 
-export type Claim = {
-  id: Scalars['String'];
-  creation: Scalars['BigInt'];
-  tokenID: Scalars['BigInt'];
-  contract: Scalars['String'];
-  uri?: Maybe<Scalars['String']>;
-  creator?: Maybe<Scalars['Bytes']>;
-  owner?: Maybe<Scalars['Bytes']>;
-  totalUnits?: Maybe<Scalars['BigInt']>;
-};
+  export type Claim = {
+    id: Scalars["String"];
+    creation: Scalars["BigInt"];
+    tokenID: Scalars["BigInt"];
+    contract: Scalars["String"];
+    uri?: Maybe<Scalars["String"]>;
+    creator?: Maybe<Scalars["Bytes"]>;
+    owner?: Maybe<Scalars["Bytes"]>;
+    totalUnits?: Maybe<Scalars["BigInt"]>;
+  };
 
-export type ClaimToken = {
-  id: Scalars['String'];
-  tokenID: Scalars['BigInt'];
-  claim: Claim;
-  owner: Scalars['Bytes'];
-  units: Scalars['BigInt'];
-};
+  export type ClaimToken = {
+    id: Scalars["String"];
+    tokenID: Scalars["BigInt"];
+    claim: Claim;
+    owner: Scalars["Bytes"];
+    units: Scalars["BigInt"];
+  };
 
-export type ClaimToken_filter = {
-  id?: InputMaybe<Scalars['String']>;
-  id_not?: InputMaybe<Scalars['String']>;
-  id_gt?: InputMaybe<Scalars['String']>;
-  id_lt?: InputMaybe<Scalars['String']>;
-  id_gte?: InputMaybe<Scalars['String']>;
-  id_lte?: InputMaybe<Scalars['String']>;
-  id_in?: InputMaybe<Array<Scalars['String']>>;
-  id_not_in?: InputMaybe<Array<Scalars['String']>>;
-  id_contains?: InputMaybe<Scalars['String']>;
-  id_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_not_contains?: InputMaybe<Scalars['String']>;
-  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_starts_with?: InputMaybe<Scalars['String']>;
-  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_starts_with?: InputMaybe<Scalars['String']>;
-  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_ends_with?: InputMaybe<Scalars['String']>;
-  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_ends_with?: InputMaybe<Scalars['String']>;
-  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  tokenID?: InputMaybe<Scalars['BigInt']>;
-  tokenID_not?: InputMaybe<Scalars['BigInt']>;
-  tokenID_gt?: InputMaybe<Scalars['BigInt']>;
-  tokenID_lt?: InputMaybe<Scalars['BigInt']>;
-  tokenID_gte?: InputMaybe<Scalars['BigInt']>;
-  tokenID_lte?: InputMaybe<Scalars['BigInt']>;
-  tokenID_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  tokenID_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  claim?: InputMaybe<Scalars['String']>;
-  claim_not?: InputMaybe<Scalars['String']>;
-  claim_gt?: InputMaybe<Scalars['String']>;
-  claim_lt?: InputMaybe<Scalars['String']>;
-  claim_gte?: InputMaybe<Scalars['String']>;
-  claim_lte?: InputMaybe<Scalars['String']>;
-  claim_in?: InputMaybe<Array<Scalars['String']>>;
-  claim_not_in?: InputMaybe<Array<Scalars['String']>>;
-  claim_contains?: InputMaybe<Scalars['String']>;
-  claim_contains_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_contains?: InputMaybe<Scalars['String']>;
-  claim_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  claim_starts_with?: InputMaybe<Scalars['String']>;
-  claim_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_starts_with?: InputMaybe<Scalars['String']>;
-  claim_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_ends_with?: InputMaybe<Scalars['String']>;
-  claim_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_not_ends_with?: InputMaybe<Scalars['String']>;
-  claim_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  claim_?: InputMaybe<Claim_filter>;
-  owner?: InputMaybe<Scalars['Bytes']>;
-  owner_not?: InputMaybe<Scalars['Bytes']>;
-  owner_gt?: InputMaybe<Scalars['Bytes']>;
-  owner_lt?: InputMaybe<Scalars['Bytes']>;
-  owner_gte?: InputMaybe<Scalars['Bytes']>;
-  owner_lte?: InputMaybe<Scalars['Bytes']>;
-  owner_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  owner_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  owner_contains?: InputMaybe<Scalars['Bytes']>;
-  owner_not_contains?: InputMaybe<Scalars['Bytes']>;
-  units?: InputMaybe<Scalars['BigInt']>;
-  units_not?: InputMaybe<Scalars['BigInt']>;
-  units_gt?: InputMaybe<Scalars['BigInt']>;
-  units_lt?: InputMaybe<Scalars['BigInt']>;
-  units_gte?: InputMaybe<Scalars['BigInt']>;
-  units_lte?: InputMaybe<Scalars['BigInt']>;
-  units_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  units_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<ClaimToken_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<ClaimToken_filter>>>;
-};
+  export type ClaimToken_filter = {
+    id?: InputMaybe<Scalars["String"]>;
+    id_not?: InputMaybe<Scalars["String"]>;
+    id_gt?: InputMaybe<Scalars["String"]>;
+    id_lt?: InputMaybe<Scalars["String"]>;
+    id_gte?: InputMaybe<Scalars["String"]>;
+    id_lte?: InputMaybe<Scalars["String"]>;
+    id_in?: InputMaybe<Array<Scalars["String"]>>;
+    id_not_in?: InputMaybe<Array<Scalars["String"]>>;
+    id_contains?: InputMaybe<Scalars["String"]>;
+    id_contains_nocase?: InputMaybe<Scalars["String"]>;
+    id_not_contains?: InputMaybe<Scalars["String"]>;
+    id_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+    id_starts_with?: InputMaybe<Scalars["String"]>;
+    id_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    id_not_starts_with?: InputMaybe<Scalars["String"]>;
+    id_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    id_ends_with?: InputMaybe<Scalars["String"]>;
+    id_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    id_not_ends_with?: InputMaybe<Scalars["String"]>;
+    id_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    tokenID?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_not?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_gt?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_lt?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_gte?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_lte?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+    tokenID_not_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+    claim?: InputMaybe<Scalars["String"]>;
+    claim_not?: InputMaybe<Scalars["String"]>;
+    claim_gt?: InputMaybe<Scalars["String"]>;
+    claim_lt?: InputMaybe<Scalars["String"]>;
+    claim_gte?: InputMaybe<Scalars["String"]>;
+    claim_lte?: InputMaybe<Scalars["String"]>;
+    claim_in?: InputMaybe<Array<Scalars["String"]>>;
+    claim_not_in?: InputMaybe<Array<Scalars["String"]>>;
+    claim_contains?: InputMaybe<Scalars["String"]>;
+    claim_contains_nocase?: InputMaybe<Scalars["String"]>;
+    claim_not_contains?: InputMaybe<Scalars["String"]>;
+    claim_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+    claim_starts_with?: InputMaybe<Scalars["String"]>;
+    claim_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    claim_not_starts_with?: InputMaybe<Scalars["String"]>;
+    claim_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    claim_ends_with?: InputMaybe<Scalars["String"]>;
+    claim_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    claim_not_ends_with?: InputMaybe<Scalars["String"]>;
+    claim_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    claim_?: InputMaybe<Claim_filter>;
+    owner?: InputMaybe<Scalars["Bytes"]>;
+    owner_not?: InputMaybe<Scalars["Bytes"]>;
+    owner_gt?: InputMaybe<Scalars["Bytes"]>;
+    owner_lt?: InputMaybe<Scalars["Bytes"]>;
+    owner_gte?: InputMaybe<Scalars["Bytes"]>;
+    owner_lte?: InputMaybe<Scalars["Bytes"]>;
+    owner_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+    owner_not_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+    owner_contains?: InputMaybe<Scalars["Bytes"]>;
+    owner_not_contains?: InputMaybe<Scalars["Bytes"]>;
+    units?: InputMaybe<Scalars["BigInt"]>;
+    units_not?: InputMaybe<Scalars["BigInt"]>;
+    units_gt?: InputMaybe<Scalars["BigInt"]>;
+    units_lt?: InputMaybe<Scalars["BigInt"]>;
+    units_gte?: InputMaybe<Scalars["BigInt"]>;
+    units_lte?: InputMaybe<Scalars["BigInt"]>;
+    units_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+    units_not_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+    /** Filter for the block changed event. */
+    _change_block?: InputMaybe<BlockChangedFilter>;
+    and?: InputMaybe<Array<InputMaybe<ClaimToken_filter>>>;
+    or?: InputMaybe<Array<InputMaybe<ClaimToken_filter>>>;
+  };
 
-export type ClaimToken_orderBy =
-  | 'id'
-  | 'tokenID'
-  | 'claim'
-  | 'owner'
-  | 'units';
+  export type ClaimToken_orderBy =
+    | "id"
+    | "tokenID"
+    | "claim"
+    | "claim__id"
+    | "claim__creation"
+    | "claim__tokenID"
+    | "claim__contract"
+    | "claim__uri"
+    | "claim__creator"
+    | "claim__owner"
+    | "claim__totalUnits"
+    | "owner"
+    | "units";
 
-export type Claim_filter = {
-  id?: InputMaybe<Scalars['String']>;
-  id_not?: InputMaybe<Scalars['String']>;
-  id_gt?: InputMaybe<Scalars['String']>;
-  id_lt?: InputMaybe<Scalars['String']>;
-  id_gte?: InputMaybe<Scalars['String']>;
-  id_lte?: InputMaybe<Scalars['String']>;
-  id_in?: InputMaybe<Array<Scalars['String']>>;
-  id_not_in?: InputMaybe<Array<Scalars['String']>>;
-  id_contains?: InputMaybe<Scalars['String']>;
-  id_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_not_contains?: InputMaybe<Scalars['String']>;
-  id_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  id_starts_with?: InputMaybe<Scalars['String']>;
-  id_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_starts_with?: InputMaybe<Scalars['String']>;
-  id_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  id_ends_with?: InputMaybe<Scalars['String']>;
-  id_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  id_not_ends_with?: InputMaybe<Scalars['String']>;
-  id_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  creation?: InputMaybe<Scalars['BigInt']>;
-  creation_not?: InputMaybe<Scalars['BigInt']>;
-  creation_gt?: InputMaybe<Scalars['BigInt']>;
-  creation_lt?: InputMaybe<Scalars['BigInt']>;
-  creation_gte?: InputMaybe<Scalars['BigInt']>;
-  creation_lte?: InputMaybe<Scalars['BigInt']>;
-  creation_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  creation_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  tokenID?: InputMaybe<Scalars['BigInt']>;
-  tokenID_not?: InputMaybe<Scalars['BigInt']>;
-  tokenID_gt?: InputMaybe<Scalars['BigInt']>;
-  tokenID_lt?: InputMaybe<Scalars['BigInt']>;
-  tokenID_gte?: InputMaybe<Scalars['BigInt']>;
-  tokenID_lte?: InputMaybe<Scalars['BigInt']>;
-  tokenID_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  tokenID_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  contract?: InputMaybe<Scalars['String']>;
-  contract_not?: InputMaybe<Scalars['String']>;
-  contract_gt?: InputMaybe<Scalars['String']>;
-  contract_lt?: InputMaybe<Scalars['String']>;
-  contract_gte?: InputMaybe<Scalars['String']>;
-  contract_lte?: InputMaybe<Scalars['String']>;
-  contract_in?: InputMaybe<Array<Scalars['String']>>;
-  contract_not_in?: InputMaybe<Array<Scalars['String']>>;
-  contract_contains?: InputMaybe<Scalars['String']>;
-  contract_contains_nocase?: InputMaybe<Scalars['String']>;
-  contract_not_contains?: InputMaybe<Scalars['String']>;
-  contract_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  contract_starts_with?: InputMaybe<Scalars['String']>;
-  contract_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  contract_not_starts_with?: InputMaybe<Scalars['String']>;
-  contract_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  contract_ends_with?: InputMaybe<Scalars['String']>;
-  contract_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  contract_not_ends_with?: InputMaybe<Scalars['String']>;
-  contract_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  uri?: InputMaybe<Scalars['String']>;
-  uri_not?: InputMaybe<Scalars['String']>;
-  uri_gt?: InputMaybe<Scalars['String']>;
-  uri_lt?: InputMaybe<Scalars['String']>;
-  uri_gte?: InputMaybe<Scalars['String']>;
-  uri_lte?: InputMaybe<Scalars['String']>;
-  uri_in?: InputMaybe<Array<Scalars['String']>>;
-  uri_not_in?: InputMaybe<Array<Scalars['String']>>;
-  uri_contains?: InputMaybe<Scalars['String']>;
-  uri_contains_nocase?: InputMaybe<Scalars['String']>;
-  uri_not_contains?: InputMaybe<Scalars['String']>;
-  uri_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  uri_starts_with?: InputMaybe<Scalars['String']>;
-  uri_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  uri_not_starts_with?: InputMaybe<Scalars['String']>;
-  uri_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  uri_ends_with?: InputMaybe<Scalars['String']>;
-  uri_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  uri_not_ends_with?: InputMaybe<Scalars['String']>;
-  uri_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  creator?: InputMaybe<Scalars['Bytes']>;
-  creator_not?: InputMaybe<Scalars['Bytes']>;
-  creator_gt?: InputMaybe<Scalars['Bytes']>;
-  creator_lt?: InputMaybe<Scalars['Bytes']>;
-  creator_gte?: InputMaybe<Scalars['Bytes']>;
-  creator_lte?: InputMaybe<Scalars['Bytes']>;
-  creator_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  creator_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  creator_contains?: InputMaybe<Scalars['Bytes']>;
-  creator_not_contains?: InputMaybe<Scalars['Bytes']>;
-  owner?: InputMaybe<Scalars['Bytes']>;
-  owner_not?: InputMaybe<Scalars['Bytes']>;
-  owner_gt?: InputMaybe<Scalars['Bytes']>;
-  owner_lt?: InputMaybe<Scalars['Bytes']>;
-  owner_gte?: InputMaybe<Scalars['Bytes']>;
-  owner_lte?: InputMaybe<Scalars['Bytes']>;
-  owner_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  owner_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  owner_contains?: InputMaybe<Scalars['Bytes']>;
-  owner_not_contains?: InputMaybe<Scalars['Bytes']>;
-  totalUnits?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_not?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_gt?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_lt?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_gte?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_lte?: InputMaybe<Scalars['BigInt']>;
-  totalUnits_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  totalUnits_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  /** Filter for the block changed event. */
-  _change_block?: InputMaybe<BlockChangedFilter>;
-  and?: InputMaybe<Array<InputMaybe<Claim_filter>>>;
-  or?: InputMaybe<Array<InputMaybe<Claim_filter>>>;
-};
+  export type Claim_filter = {
+    id?: InputMaybe<Scalars["String"]>;
+    id_not?: InputMaybe<Scalars["String"]>;
+    id_gt?: InputMaybe<Scalars["String"]>;
+    id_lt?: InputMaybe<Scalars["String"]>;
+    id_gte?: InputMaybe<Scalars["String"]>;
+    id_lte?: InputMaybe<Scalars["String"]>;
+    id_in?: InputMaybe<Array<Scalars["String"]>>;
+    id_not_in?: InputMaybe<Array<Scalars["String"]>>;
+    id_contains?: InputMaybe<Scalars["String"]>;
+    id_contains_nocase?: InputMaybe<Scalars["String"]>;
+    id_not_contains?: InputMaybe<Scalars["String"]>;
+    id_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+    id_starts_with?: InputMaybe<Scalars["String"]>;
+    id_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    id_not_starts_with?: InputMaybe<Scalars["String"]>;
+    id_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    id_ends_with?: InputMaybe<Scalars["String"]>;
+    id_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    id_not_ends_with?: InputMaybe<Scalars["String"]>;
+    id_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    creation?: InputMaybe<Scalars["BigInt"]>;
+    creation_not?: InputMaybe<Scalars["BigInt"]>;
+    creation_gt?: InputMaybe<Scalars["BigInt"]>;
+    creation_lt?: InputMaybe<Scalars["BigInt"]>;
+    creation_gte?: InputMaybe<Scalars["BigInt"]>;
+    creation_lte?: InputMaybe<Scalars["BigInt"]>;
+    creation_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+    creation_not_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+    tokenID?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_not?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_gt?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_lt?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_gte?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_lte?: InputMaybe<Scalars["BigInt"]>;
+    tokenID_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+    tokenID_not_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+    contract?: InputMaybe<Scalars["String"]>;
+    contract_not?: InputMaybe<Scalars["String"]>;
+    contract_gt?: InputMaybe<Scalars["String"]>;
+    contract_lt?: InputMaybe<Scalars["String"]>;
+    contract_gte?: InputMaybe<Scalars["String"]>;
+    contract_lte?: InputMaybe<Scalars["String"]>;
+    contract_in?: InputMaybe<Array<Scalars["String"]>>;
+    contract_not_in?: InputMaybe<Array<Scalars["String"]>>;
+    contract_contains?: InputMaybe<Scalars["String"]>;
+    contract_contains_nocase?: InputMaybe<Scalars["String"]>;
+    contract_not_contains?: InputMaybe<Scalars["String"]>;
+    contract_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+    contract_starts_with?: InputMaybe<Scalars["String"]>;
+    contract_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    contract_not_starts_with?: InputMaybe<Scalars["String"]>;
+    contract_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    contract_ends_with?: InputMaybe<Scalars["String"]>;
+    contract_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    contract_not_ends_with?: InputMaybe<Scalars["String"]>;
+    contract_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    uri?: InputMaybe<Scalars["String"]>;
+    uri_not?: InputMaybe<Scalars["String"]>;
+    uri_gt?: InputMaybe<Scalars["String"]>;
+    uri_lt?: InputMaybe<Scalars["String"]>;
+    uri_gte?: InputMaybe<Scalars["String"]>;
+    uri_lte?: InputMaybe<Scalars["String"]>;
+    uri_in?: InputMaybe<Array<Scalars["String"]>>;
+    uri_not_in?: InputMaybe<Array<Scalars["String"]>>;
+    uri_contains?: InputMaybe<Scalars["String"]>;
+    uri_contains_nocase?: InputMaybe<Scalars["String"]>;
+    uri_not_contains?: InputMaybe<Scalars["String"]>;
+    uri_not_contains_nocase?: InputMaybe<Scalars["String"]>;
+    uri_starts_with?: InputMaybe<Scalars["String"]>;
+    uri_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    uri_not_starts_with?: InputMaybe<Scalars["String"]>;
+    uri_not_starts_with_nocase?: InputMaybe<Scalars["String"]>;
+    uri_ends_with?: InputMaybe<Scalars["String"]>;
+    uri_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    uri_not_ends_with?: InputMaybe<Scalars["String"]>;
+    uri_not_ends_with_nocase?: InputMaybe<Scalars["String"]>;
+    creator?: InputMaybe<Scalars["Bytes"]>;
+    creator_not?: InputMaybe<Scalars["Bytes"]>;
+    creator_gt?: InputMaybe<Scalars["Bytes"]>;
+    creator_lt?: InputMaybe<Scalars["Bytes"]>;
+    creator_gte?: InputMaybe<Scalars["Bytes"]>;
+    creator_lte?: InputMaybe<Scalars["Bytes"]>;
+    creator_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+    creator_not_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+    creator_contains?: InputMaybe<Scalars["Bytes"]>;
+    creator_not_contains?: InputMaybe<Scalars["Bytes"]>;
+    owner?: InputMaybe<Scalars["Bytes"]>;
+    owner_not?: InputMaybe<Scalars["Bytes"]>;
+    owner_gt?: InputMaybe<Scalars["Bytes"]>;
+    owner_lt?: InputMaybe<Scalars["Bytes"]>;
+    owner_gte?: InputMaybe<Scalars["Bytes"]>;
+    owner_lte?: InputMaybe<Scalars["Bytes"]>;
+    owner_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+    owner_not_in?: InputMaybe<Array<Scalars["Bytes"]>>;
+    owner_contains?: InputMaybe<Scalars["Bytes"]>;
+    owner_not_contains?: InputMaybe<Scalars["Bytes"]>;
+    totalUnits?: InputMaybe<Scalars["BigInt"]>;
+    totalUnits_not?: InputMaybe<Scalars["BigInt"]>;
+    totalUnits_gt?: InputMaybe<Scalars["BigInt"]>;
+    totalUnits_lt?: InputMaybe<Scalars["BigInt"]>;
+    totalUnits_gte?: InputMaybe<Scalars["BigInt"]>;
+    totalUnits_lte?: InputMaybe<Scalars["BigInt"]>;
+    totalUnits_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+    totalUnits_not_in?: InputMaybe<Array<Scalars["BigInt"]>>;
+    /** Filter for the block changed event. */
+    _change_block?: InputMaybe<BlockChangedFilter>;
+    and?: InputMaybe<Array<InputMaybe<Claim_filter>>>;
+    or?: InputMaybe<Array<InputMaybe<Claim_filter>>>;
+  };
 
-export type Claim_orderBy =
-  | 'id'
-  | 'creation'
-  | 'tokenID'
-  | 'contract'
-  | 'uri'
-  | 'creator'
-  | 'owner'
-  | 'totalUnits';
+  export type Claim_orderBy = "id" | "creation" | "tokenID" | "contract" | "uri" | "creator" | "owner" | "totalUnits";
 
-/** Defines the order direction, either ascending or descending */
-export type OrderDirection =
-  | 'asc'
-  | 'desc';
+  /** Defines the order direction, either ascending or descending */
+  export type OrderDirection = "asc" | "desc";
 
-export type Query = {
-  allowlist?: Maybe<Allowlist>;
-  allowlists: Array<Allowlist>;
-  claim?: Maybe<Claim>;
-  claims: Array<Claim>;
-  claimToken?: Maybe<ClaimToken>;
-  claimTokens: Array<ClaimToken>;
-  /** Access to subgraph metadata */
-  _meta?: Maybe<_Meta_>;
-};
+  export type Query = {
+    allowlist?: Maybe<Allowlist>;
+    allowlists: Array<Allowlist>;
+    claim?: Maybe<Claim>;
+    claims: Array<Claim>;
+    claimToken?: Maybe<ClaimToken>;
+    claimTokens: Array<ClaimToken>;
+    /** Access to subgraph metadata */
+    _meta?: Maybe<_Meta_>;
+  };
 
+  export type QueryallowlistArgs = {
+    id: Scalars["ID"];
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
-export type QueryallowlistArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
+  export type QueryallowlistsArgs = {
+    skip?: InputMaybe<Scalars["Int"]>;
+    first?: InputMaybe<Scalars["Int"]>;
+    orderBy?: InputMaybe<Allowlist_orderBy>;
+    orderDirection?: InputMaybe<OrderDirection>;
+    where?: InputMaybe<Allowlist_filter>;
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
+  export type QueryclaimArgs = {
+    id: Scalars["ID"];
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
-export type QueryallowlistsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Allowlist_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Allowlist_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
+  export type QueryclaimsArgs = {
+    skip?: InputMaybe<Scalars["Int"]>;
+    first?: InputMaybe<Scalars["Int"]>;
+    orderBy?: InputMaybe<Claim_orderBy>;
+    orderDirection?: InputMaybe<OrderDirection>;
+    where?: InputMaybe<Claim_filter>;
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
+  export type QueryclaimTokenArgs = {
+    id: Scalars["ID"];
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
-export type QueryclaimArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
+  export type QueryclaimTokensArgs = {
+    skip?: InputMaybe<Scalars["Int"]>;
+    first?: InputMaybe<Scalars["Int"]>;
+    orderBy?: InputMaybe<ClaimToken_orderBy>;
+    orderDirection?: InputMaybe<OrderDirection>;
+    where?: InputMaybe<ClaimToken_filter>;
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
+  export type Query_metaArgs = {
+    block?: InputMaybe<Block_height>;
+  };
 
-export type QueryclaimsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Claim_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Claim_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
+  export type Subscription = {
+    allowlist?: Maybe<Allowlist>;
+    allowlists: Array<Allowlist>;
+    claim?: Maybe<Claim>;
+    claims: Array<Claim>;
+    claimToken?: Maybe<ClaimToken>;
+    claimTokens: Array<ClaimToken>;
+    /** Access to subgraph metadata */
+    _meta?: Maybe<_Meta_>;
+  };
 
+  export type SubscriptionallowlistArgs = {
+    id: Scalars["ID"];
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
-export type QueryclaimTokenArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
+  export type SubscriptionallowlistsArgs = {
+    skip?: InputMaybe<Scalars["Int"]>;
+    first?: InputMaybe<Scalars["Int"]>;
+    orderBy?: InputMaybe<Allowlist_orderBy>;
+    orderDirection?: InputMaybe<OrderDirection>;
+    where?: InputMaybe<Allowlist_filter>;
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
+  export type SubscriptionclaimArgs = {
+    id: Scalars["ID"];
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
-export type QueryclaimTokensArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<ClaimToken_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<ClaimToken_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
+  export type SubscriptionclaimsArgs = {
+    skip?: InputMaybe<Scalars["Int"]>;
+    first?: InputMaybe<Scalars["Int"]>;
+    orderBy?: InputMaybe<Claim_orderBy>;
+    orderDirection?: InputMaybe<OrderDirection>;
+    where?: InputMaybe<Claim_filter>;
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
+  export type SubscriptionclaimTokenArgs = {
+    id: Scalars["ID"];
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
-export type Query_metaArgs = {
-  block?: InputMaybe<Block_height>;
-};
+  export type SubscriptionclaimTokensArgs = {
+    skip?: InputMaybe<Scalars["Int"]>;
+    first?: InputMaybe<Scalars["Int"]>;
+    orderBy?: InputMaybe<ClaimToken_orderBy>;
+    orderDirection?: InputMaybe<OrderDirection>;
+    where?: InputMaybe<ClaimToken_filter>;
+    block?: InputMaybe<Block_height>;
+    subgraphError?: _SubgraphErrorPolicy_;
+  };
 
-export type Subscription = {
-  allowlist?: Maybe<Allowlist>;
-  allowlists: Array<Allowlist>;
-  claim?: Maybe<Claim>;
-  claims: Array<Claim>;
-  claimToken?: Maybe<ClaimToken>;
-  claimTokens: Array<ClaimToken>;
-  /** Access to subgraph metadata */
-  _meta?: Maybe<_Meta_>;
-};
+  export type Subscription_metaArgs = {
+    block?: InputMaybe<Block_height>;
+  };
 
+  export type _Block_ = {
+    /** The hash of the block */
+    hash?: Maybe<Scalars["Bytes"]>;
+    /** The block number */
+    number: Scalars["Int"];
+    /** Integer representation of the timestamp stored in blocks for the chain */
+    timestamp?: Maybe<Scalars["Int"]>;
+  };
 
-export type SubscriptionallowlistArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
+  /** The type for the top-level _meta field */
+  export type _Meta_ = {
+    /**
+     * Information about a specific subgraph block. The hash of the block
+     * will be null if the _meta field has a block constraint that asks for
+     * a block number. It will be filled if the _meta field has no block constraint
+     * and therefore asks for the latest  block
+     *
+     */
+    block: _Block_;
+    /** The deployment ID */
+    deployment: Scalars["String"];
+    /** If `true`, the subgraph encountered indexing errors at some past block */
+    hasIndexingErrors: Scalars["Boolean"];
+  };
 
-
-export type SubscriptionallowlistsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Allowlist_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Allowlist_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptionclaimArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptionclaimsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Claim_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<Claim_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptionclaimTokenArgs = {
-  id: Scalars['ID'];
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type SubscriptionclaimTokensArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<ClaimToken_orderBy>;
-  orderDirection?: InputMaybe<OrderDirection>;
-  where?: InputMaybe<ClaimToken_filter>;
-  block?: InputMaybe<Block_height>;
-  subgraphError?: _SubgraphErrorPolicy_;
-};
-
-
-export type Subscription_metaArgs = {
-  block?: InputMaybe<Block_height>;
-};
-
-export type _Block_ = {
-  /** The hash of the block */
-  hash?: Maybe<Scalars['Bytes']>;
-  /** The block number */
-  number: Scalars['Int'];
-  /** Integer representation of the timestamp stored in blocks for the chain */
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** The type for the top-level _meta field */
-export type _Meta_ = {
-  /**
-   * Information about a specific subgraph block. The hash of the block
-   * will be null if the _meta field has a block constraint that asks for
-   * a block number. It will be filled if the _meta field has no block constraint
-   * and therefore asks for the latest  block
-   *
-   */
-  block: _Block_;
-  /** The deployment ID */
-  deployment: Scalars['String'];
-  /** If `true`, the subgraph encountered indexing errors at some past block */
-  hasIndexingErrors: Scalars['Boolean'];
-};
-
-export type _SubgraphErrorPolicy_ =
-  /** Data will be returned even if the subgraph has indexing errors */
-  | 'allow'
-  /** If the subgraph has indexing errors, data will be omitted. The default. */
-  | 'deny';
+  export type _SubgraphErrorPolicy_ =
+    /** Data will be returned even if the subgraph has indexing errors */
+    | "allow"
+    /** If the subgraph has indexing errors, data will be omitted. The default. */
+    | "deny";
 
   export type QuerySdk = {
-      /** null **/
-  allowlist: InContextSdkMethod<Query['allowlist'], QueryallowlistArgs, MeshContext>,
-  /** null **/
-  allowlists: InContextSdkMethod<Query['allowlists'], QueryallowlistsArgs, MeshContext>,
-  /** null **/
-  claim: InContextSdkMethod<Query['claim'], QueryclaimArgs, MeshContext>,
-  /** null **/
-  claims: InContextSdkMethod<Query['claims'], QueryclaimsArgs, MeshContext>,
-  /** null **/
-  claimToken: InContextSdkMethod<Query['claimToken'], QueryclaimTokenArgs, MeshContext>,
-  /** null **/
-  claimTokens: InContextSdkMethod<Query['claimTokens'], QueryclaimTokensArgs, MeshContext>,
-  /** Access to subgraph metadata **/
-  _meta: InContextSdkMethod<Query['_meta'], Query_metaArgs, MeshContext>
+    /** null **/
+    allowlist: InContextSdkMethod<Query["allowlist"], QueryallowlistArgs, MeshContext>;
+    /** null **/
+    allowlists: InContextSdkMethod<Query["allowlists"], QueryallowlistsArgs, MeshContext>;
+    /** null **/
+    claim: InContextSdkMethod<Query["claim"], QueryclaimArgs, MeshContext>;
+    /** null **/
+    claims: InContextSdkMethod<Query["claims"], QueryclaimsArgs, MeshContext>;
+    /** null **/
+    claimToken: InContextSdkMethod<Query["claimToken"], QueryclaimTokenArgs, MeshContext>;
+    /** null **/
+    claimTokens: InContextSdkMethod<Query["claimTokens"], QueryclaimTokensArgs, MeshContext>;
+    /** Access to subgraph metadata **/
+    _meta: InContextSdkMethod<Query["_meta"], Query_metaArgs, MeshContext>;
   };
 
-  export type MutationSdk = {
-    
-  };
+  export type MutationSdk = {};
 
   export type SubscriptionSdk = {
-      /** null **/
-  allowlist: InContextSdkMethod<Subscription['allowlist'], SubscriptionallowlistArgs, MeshContext>,
-  /** null **/
-  allowlists: InContextSdkMethod<Subscription['allowlists'], SubscriptionallowlistsArgs, MeshContext>,
-  /** null **/
-  claim: InContextSdkMethod<Subscription['claim'], SubscriptionclaimArgs, MeshContext>,
-  /** null **/
-  claims: InContextSdkMethod<Subscription['claims'], SubscriptionclaimsArgs, MeshContext>,
-  /** null **/
-  claimToken: InContextSdkMethod<Subscription['claimToken'], SubscriptionclaimTokenArgs, MeshContext>,
-  /** null **/
-  claimTokens: InContextSdkMethod<Subscription['claimTokens'], SubscriptionclaimTokensArgs, MeshContext>,
-  /** Access to subgraph metadata **/
-  _meta: InContextSdkMethod<Subscription['_meta'], Subscription_metaArgs, MeshContext>
+    /** null **/
+    allowlist: InContextSdkMethod<Subscription["allowlist"], SubscriptionallowlistArgs, MeshContext>;
+    /** null **/
+    allowlists: InContextSdkMethod<Subscription["allowlists"], SubscriptionallowlistsArgs, MeshContext>;
+    /** null **/
+    claim: InContextSdkMethod<Subscription["claim"], SubscriptionclaimArgs, MeshContext>;
+    /** null **/
+    claims: InContextSdkMethod<Subscription["claims"], SubscriptionclaimsArgs, MeshContext>;
+    /** null **/
+    claimToken: InContextSdkMethod<Subscription["claimToken"], SubscriptionclaimTokenArgs, MeshContext>;
+    /** null **/
+    claimTokens: InContextSdkMethod<Subscription["claimTokens"], SubscriptionclaimTokensArgs, MeshContext>;
+    /** Access to subgraph metadata **/
+    _meta: InContextSdkMethod<Subscription["_meta"], Subscription_metaArgs, MeshContext>;
   };
 
   export type Context = {
-      ["hypercerts-dev"]: { Query: QuerySdk, Mutation: MutationSdk, Subscription: SubscriptionSdk },
-      
-    };
+    ["hypercerts-dev"]: { Query: QuerySdk; Mutation: MutationSdk; Subscription: SubscriptionSdk };
+  };
 }

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -1,0 +1,9 @@
+/**
+ * Fails fetching a remote resource
+ */
+export class FetchError extends Error {}
+
+/**
+ * Data doesn't conform to expectations
+ */
+export class MalformedDataError extends Error {}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,18 +1,9 @@
 // Validation
 import { validateMetaData, validateClaimData } from "./validator/index.js";
 import { formatHypercertData } from "./formatter.js";
-import { storeMetadata, storeData, getMetadata, getData, deleteMetadata } from "./operator/index.js";
+import { storeMetadata, storeData, getMetadata, getData } from "./operator/index.js";
 
-export {
-  validateMetaData,
-  validateClaimData,
-  storeMetadata,
-  storeData,
-  getMetadata,
-  getData,
-  deleteMetadata,
-  formatHypercertData,
-};
+export { validateMetaData, validateClaimData, storeMetadata, storeData, getMetadata, getData, formatHypercertData };
 
 // Graph
 import { execute } from "./.graphclient/index.js";

--- a/sdk/test/interface.test.ts
+++ b/sdk/test/interface.test.ts
@@ -9,7 +9,6 @@ describe("Interface spec", () => {
       storeData: expect.any(Function),
       getMetadata: expect.any(Function),
       getData: expect.any(Function),
-      deleteMetadata: expect.any(Function),
     });
   });
 

--- a/sdk/test/operator.test.ts
+++ b/sdk/test/operator.test.ts
@@ -4,7 +4,7 @@ import metadata from "./res/mockMetadata.js";
 import data from "./res/mockData.js";
 
 import { HypercertMetadata } from "../src/types/metadata.js";
-import { getIpfsGatewayUri } from "../src/operator/index.js";
+import { getNftStorageGatewayUri } from "../src/operator/index.js";
 
 const mockMetadata = JSON.parse(`
 {
@@ -28,7 +28,7 @@ const mockData = JSON.parse(`{
 
 const mockMetadataCid = "bafkreigdm2flneb4khd7eixodagst5nrndptgezrjux7gohxcngjn67x6u";
 
-const mockDataCid = "bafkreif5otrkydrrjbp532a75hkm5goefxv5rqg35d2wqm6oveht4hqto4";
+const mockDataCid = "bafybeifenmt2wocehkcslpk5gfrbxviymzwgfra24unt3xgs76snqsry2i";
 
 describe("IPFS Client", () => {
   /**
@@ -54,13 +54,12 @@ describe("IPFS Client", () => {
 
   it("Smoke test - get data", async () => {
     const data = await getData(mockDataCid);
-
     expect(data).to.deep.equal(mockData);
   });
 
   it("Removes ipfs:// prefix if present to get CID", () => {
-    const uriFromCid = getIpfsGatewayUri(mockDataCid);
-    const uriFromIpfsLink = getIpfsGatewayUri(`ipfs://${mockDataCid}`);
+    const uriFromCid = getNftStorageGatewayUri(mockDataCid);
+    const uriFromIpfsLink = getNftStorageGatewayUri(`ipfs://${mockDataCid}`);
     expect(uriFromCid).to.eq(uriFromIpfsLink);
   });
 });

--- a/sdk/yarn.lock
+++ b/sdk/yarn.lock
@@ -1889,7 +1889,7 @@
     ws "*"
     xtend "^4.0.0"
 
-"@ipld/car@^3.0.1", "@ipld/car@^3.2.3":
+"@ipld/car@^3.0.1", "@ipld/car@^3.1.4", "@ipld/car@^3.2.3":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@ipld/car/-/car-3.2.4.tgz#115951ba2255ec51d865773a074e422c169fb01c"
   integrity sha512-rezKd+jk8AsTGOoJKqzfjLJ3WVft7NZNH95f0pfPbicROvzTyvHCNy567HzSUd6gRXZ9im29z5ZEv9Hw49jSYw==
@@ -2984,10 +2984,20 @@
   resolved "https://registry.yarnpkg.com/@network-goods/hypercerts-protocol/-/hypercerts-protocol-0.0.9.tgz#515ce10092515ee25036fdd627719954da2d7621"
   integrity sha512-C4CtUQf3F0sj48IgaNb/E5KanhxIeLA4e9fBR1xKcdf+DicZBxCYlWfzp4jyiEn7oo27Un0fZXhRgj4D4ZQH1A==
 
+"@noble/ed25519@^1.5.1":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
+  integrity sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==
+
 "@noble/ed25519@^1.6.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@noble/ed25519/-/ed25519-1.7.1.tgz#6899660f6fbb97798a6fbd227227c4589a454724"
   integrity sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==
+
+"@noble/secp256k1@^1.3.0":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
+  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@noble/secp256k1@^1.5.4":
   version "1.7.0"
@@ -3468,7 +3478,7 @@
   resolved "https://registry.yarnpkg.com/@vascosantos/moving-average/-/moving-average-1.1.0.tgz#8d5793b09b2d6021ba5e620c6a0f876c20db7eaa"
   integrity sha512-MVEJ4vWAPNbrGLjz7ITnHYg+YXZ6ijAqtH5/cHwSoCpbvuJ98aLXwFfPKAUfZpJMQR5uXB58UJajbY130IRF/w==
 
-"@web-std/blob@^3.0.1", "@web-std/blob@^3.0.3":
+"@web-std/blob@^3.0.1", "@web-std/blob@^3.0.3", "@web-std/blob@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@web-std/blob/-/blob-3.0.4.tgz#dd67a685547331915428d69e723c7da2015c3fc5"
   integrity sha512-+dibyiw+uHYK4dX5cJ7HA+gtDAaUUe6JsOryp2ZpAC7h4ICsh49E34JwHoEKPlPvP0llCrNzz45vvD+xX5QDBg==
@@ -3486,7 +3496,19 @@
     "@web3-storage/multipart-parser" "^1.0.0"
     data-uri-to-buffer "^3.0.1"
 
-"@web-std/file@^3.0.0":
+"@web-std/fetch@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@web-std/fetch/-/fetch-4.1.0.tgz#db1eb659198376dad692421896b7119fb13e6e52"
+  integrity sha512-ZRizMcP8YyuRlhIsRYNFD9x/w28K7kbUhNGmKM9hDy4qeQ5xMTk//wA89EF+Clbl6EP4ksmCcN+4TqBMSRL8Zw==
+  dependencies:
+    "@web-std/blob" "^3.0.3"
+    "@web-std/form-data" "^3.0.2"
+    "@web-std/stream" "^1.0.1"
+    "@web3-storage/multipart-parser" "^1.0.0"
+    data-uri-to-buffer "^3.0.1"
+    mrmime "^1.0.0"
+
+"@web-std/file@^3.0.0", "@web-std/file@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@web-std/file/-/file-3.0.2.tgz#b84cc9ed754608b18dcf78ac62c40dbcc6a94692"
   integrity sha512-pIH0uuZsmY8YFvSHP1NsBIiMT/1ce0suPrX74fEeO3Wbr1+rW0fUGEe4d0R99iLwXtyCwyserqCFI4BJkJlkRA==
@@ -3507,10 +3529,22 @@
   dependencies:
     web-streams-polyfill "^3.1.1"
 
+"@web-std/stream@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@web-std/stream/-/stream-1.0.1.tgz#af2972654848e20a683781b0a50bef2ce3f011a0"
+  integrity sha512-tsz4Y0WNDgFA5jwLSeV7/UV5rfMIlj0cPsSLVfTihjaVW0OJPd5NxJ3le1B3yLyqqzRpeG5OAfJAADLc4VoGTA==
+  dependencies:
+    web-streams-polyfill "^3.1.1"
+
 "@web3-storage/multipart-parser@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz#6b69dc2a32a5b207ba43e556c25cc136a56659c4"
   integrity sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==
+
+"@web3-storage/parse-link-header@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@web3-storage/parse-link-header/-/parse-link-header-3.1.0.tgz#4562724987649dd6d3e07c87be1826804d212ef7"
+  integrity sha512-K1undnK70vLLauqdE8bq/l98isTF2FDhcP0UPpXVSjkSWe3xhAn5eRXk5jfA1E5ycNm84Ws/rQFUD7ue11nciw==
 
 "@whatwg-node/events@0.0.2":
   version "0.0.2"
@@ -4220,6 +4254,11 @@ cborg@^1.3.3, cborg@^1.3.4, cborg@^1.5.4, cborg@^1.6.0, cborg@^1.9.0:
   resolved "https://registry.yarnpkg.com/cborg/-/cborg-1.9.6.tgz#bf90de6541d10735db878b60b4af824209b77435"
   integrity sha512-XmiD+NWTk9xg31d8MdXgW46bSZd95ELllxjbjdWGyHAtpTw+cf8iG3NibWgTWRnfWfxtcihVa5Pm0gchHiO3JQ==
 
+cborg@^1.8.0, cborg@^1.9.4:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/cborg/-/cborg-1.10.0.tgz#0fe157961dd47b537ccb84dc9ba681de8b699013"
+  integrity sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ==
+
 chai@^4.3.7:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
@@ -4319,6 +4358,11 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
+
+class-is@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/class-is/-/class-is-1.1.0.tgz#9d3c0fba0440d211d843cec3dedfa48055005825"
+  integrity sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==
 
 classic-level@^1.2.0:
   version "1.2.0"
@@ -5240,6 +5284,16 @@ file-uri-to-path@2:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz#7b415aeba227d575851e0a5b0c640d7656403fba"
   integrity sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==
 
+files-from-path@^0.2.4:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/files-from-path/-/files-from-path-0.2.6.tgz#a093918d67ebfe1d50fffef926855574146cf571"
+  integrity sha512-Mz4UNkv+WcRLxcCXAORbfpwYiXI60SN9C1ZfeyGFv0xQUmblgbOkSWwFwX+Ov/TaR3FEyzwDyPnCQjpPRGSxKA==
+  dependencies:
+    err-code "^3.0.1"
+    graceful-fs "^4.2.9"
+    ipfs-unixfs "^6.0.5"
+    it-glob "^0.0.13"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -5949,6 +6003,33 @@ ipfs-car@^0.6.2:
     streaming-iterables "^6.0.0"
     uint8arrays "^3.0.0"
 
+ipfs-car@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/ipfs-car/-/ipfs-car-0.7.0.tgz#72955d2b6904e87edfa17bbe5c00c1b3fcb79bb9"
+  integrity sha512-9ser6WWZ1ZMTCGbcVkRXUzOrpQ4SIiLfzIEnk+3LQsXbV09yeZg3ijhRuEXozEIYE68Go9JmOFshamsK9iKlNQ==
+  dependencies:
+    "@ipld/car" "^3.2.3"
+    "@web-std/blob" "^3.0.1"
+    bl "^5.0.0"
+    blockstore-core "^1.0.2"
+    browser-readablestream-to-it "^1.0.2"
+    idb-keyval "^6.0.3"
+    interface-blockstore "^2.0.2"
+    ipfs-core-types "^0.8.3"
+    ipfs-core-utils "^0.12.1"
+    ipfs-unixfs-exporter "^7.0.4"
+    ipfs-unixfs-importer "^9.0.4"
+    ipfs-utils "^9.0.2"
+    it-all "^1.0.5"
+    it-last "^1.0.5"
+    it-pipe "^1.1.0"
+    meow "^9.0.0"
+    move-file "^2.1.0"
+    multiformats "^9.6.3"
+    stream-to-it "^0.2.3"
+    streaming-iterables "^6.0.0"
+    uint8arrays "^3.0.0"
+
 ipfs-core-config@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/ipfs-core-config/-/ipfs-core-config-0.6.0.tgz#47ce9313351212bbbeb99acfa9c857ac8634bc5e"
@@ -6286,7 +6367,7 @@ ipfs-unixfs-importer@^9.0.4:
     rabin-wasm "^0.1.4"
     uint8arrays "^3.0.0"
 
-ipfs-unixfs@^6.0.0, ipfs-unixfs@^6.0.3:
+ipfs-unixfs@^6.0.0, ipfs-unixfs@^6.0.3, ipfs-unixfs@^6.0.5:
   version "6.0.9"
   resolved "https://registry.yarnpkg.com/ipfs-unixfs/-/ipfs-unixfs-6.0.9.tgz#f6613b8e081d83faa43ed96e016a694c615a9374"
   integrity sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==
@@ -6321,6 +6402,23 @@ ipfs-utils@^9.0.2, ipfs-utils@^9.0.6:
     node-fetch "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz"
     react-native-fetch-api "^2.0.0"
     stream-to-it "^0.2.2"
+
+ipns@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/ipns/-/ipns-0.16.0.tgz#656bf36d78a6a9eb829ff798b4ca875ba9a3d0d4"
+  integrity sha512-fBYkRjN3/fc6IQujUF4WBEyOXegK715w+wx9IErV6H2B5JXsMnHOBceUKn3L90dj+wJfHs6T+hM/OZiTT6mQCw==
+  dependencies:
+    cborg "^1.3.3"
+    debug "^4.2.0"
+    err-code "^3.0.1"
+    interface-datastore "^6.0.2"
+    libp2p-crypto "^0.21.0"
+    long "^4.0.0"
+    multiformats "^9.4.5"
+    peer-id "^0.16.0"
+    protobufjs "^6.10.2"
+    timestamp-nano "^1.0.0"
+    uint8arrays "^3.0.0"
 
 ipns@^4.0.0:
   version "4.0.0"
@@ -6552,7 +6650,7 @@ iso-constants@^0.1.2:
   resolved "https://registry.yarnpkg.com/iso-constants/-/iso-constants-0.1.2.tgz#3d2456ed5aeaa55d18564f285ba02a47a0d885b4"
   integrity sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ==
 
-iso-random-stream@^2.0.2:
+iso-random-stream@^2.0.0, iso-random-stream@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/iso-random-stream/-/iso-random-stream-2.0.2.tgz#a24f77c34cfdad9d398707d522a6a0cc640ff27d"
   integrity sha512-yJvs+Nnelic1L2vH2JzWvvPQFA4r7kSTnpST/+LkAQjSz0hos2oqLD+qIVi9Qk38Hoe7mNDt3j0S27R58MVjLQ==
@@ -6709,6 +6807,14 @@ it-foreach@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/it-foreach/-/it-foreach-1.0.0.tgz#43b3f04661ef0809a4ce03150ef1f66a3f63ed23"
   integrity sha512-2j5HK1P6aMwEvgL6K5nzUwOk+81B/mjt05PxiSspFEKwJnqy1LfJYlLLS6llBoM+NdoUxf6EsBCHidFGmsXvhw==
+
+it-glob@^0.0.13:
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/it-glob/-/it-glob-0.0.13.tgz#78913fe835fcf0d46afcdb6634eb069acdfc4fbc"
+  integrity sha512-0Hcd5BraJUPzL28NWiFbdNrcdyNxNTKKdU3sjdFiYynNTQpwlG2UKW31X7bp+XhJwux/oPzIquo5ioztVmc2RQ==
+  dependencies:
+    "@types/minimatch" "^3.0.4"
+    minimatch "^3.0.4"
 
 it-glob@^1.0.1:
   version "1.0.2"
@@ -7548,6 +7654,20 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+libp2p-crypto@^0.21.0, libp2p-crypto@^0.21.2:
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.21.2.tgz#7f9875436f24ca3887b077210b217b702bd72916"
+  integrity sha512-EXFrhSpiHtJ+/L8xXDvQNK5VjUMG51u878jzZcaT5XhuN/zFg6PWJFnl/qB2Y2j7eMWnvCRP7Kp+ua2H36cG4g==
+  dependencies:
+    "@noble/ed25519" "^1.5.1"
+    "@noble/secp256k1" "^1.3.0"
+    err-code "^3.0.1"
+    iso-random-stream "^2.0.0"
+    multiformats "^9.4.5"
+    node-forge "^1.2.1"
+    protobufjs "^6.11.2"
+    uint8arrays "^3.0.0"
+
 libp2p@^0.40.0:
   version "0.40.0"
   resolved "https://registry.yarnpkg.com/libp2p/-/libp2p-0.40.0.tgz#c93b586d99f58192b43801444053536a5f9cbbd1"
@@ -8020,6 +8140,11 @@ move-file@^2.1.0:
   dependencies:
     path-exists "^4.0.0"
 
+mrmime@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
+  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -8427,7 +8552,7 @@ p-reflect@^3.1.0:
   resolved "https://registry.yarnpkg.com/p-reflect/-/p-reflect-3.1.0.tgz#bba22747439b5fc50a7f626e8e909dc9b888218d"
   integrity sha512-3sG3UlpisPSaX+o7u2q01hIQmrpkvdl5GSO1ZwL7pfc5kHB2bPF0eFNCfYTrW1/LTUdgmPwBAvmT0Zr8eSmaAQ==
 
-p-retry@^4.6.1:
+p-retry@^4.5.0, p-retry@^4.6.1:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
   integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
@@ -8621,6 +8746,17 @@ pathval@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
+peer-id@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/peer-id/-/peer-id-0.16.0.tgz#0913062cfa4378707fe69c949b5720b3efadbf32"
+  integrity sha512-EmL7FurFUduU9m1PS9cfJ5TAuCvxKQ7DKpfx3Yj6IKWyBRtosriFuOag/l3ni/dtPgPLwiA4R9IvpL7hsDLJuQ==
+  dependencies:
+    class-is "^1.1.0"
+    libp2p-crypto "^0.21.0"
+    multiformats "^9.4.5"
+    protobufjs "^6.10.2"
+    uint8arrays "^3.0.0"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -9485,7 +9621,7 @@ stream-to-it@^0.2.2, stream-to-it@^0.2.3:
   dependencies:
     get-iterator "^1.0.2"
 
-streaming-iterables@^6.0.0:
+streaming-iterables@^6.0.0, streaming-iterables@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/streaming-iterables/-/streaming-iterables-6.2.0.tgz#e8079bc56272335b287e2f13274602fbef008e56"
   integrity sha512-3AYC8oB60WyD1ic7uHmN/vm2oRGzRnQ3XFBl/bFMDi1q1+nc5/vjMmiE4vroIya3jG59t87VpyAj/iXYxyw9AA==
@@ -9626,7 +9762,7 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-throttled-queue@^2.1.2:
+throttled-queue@^2.1.2, throttled-queue@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/throttled-queue/-/throttled-queue-2.1.4.tgz#4e2008c73ab3f72ba1bb09496c3cc9c5b745dbee"
   integrity sha512-YGdk8sdmr4ge3g+doFj/7RLF5kLM+Mi7DEciu9PHxnMJZMeVuZeTj31g4VE7ekUffx/IdbvrtOCiz62afg0mkg==
@@ -10061,6 +10197,18 @@ vm2@^3.9.8:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"
 
+w3name@^1.0.4:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/w3name/-/w3name-1.0.8.tgz#d951a6b93871fb4a95974fdfc45f449fce69fe42"
+  integrity sha512-MjCUGATeNm70YE1Zro4mykaoRI9dTTlr44AB83Qt6OaRlcLvH9g0gyLwAMd3gBm8oDVU/RrDAxsDGcO8r+RIuQ==
+  dependencies:
+    "@web-std/fetch" "^4.1.0"
+    cborg "^1.9.4"
+    ipns "^0.16.0"
+    libp2p-crypto "^0.21.2"
+    throttled-queue "^2.1.4"
+    uint8arrays "^3.0.0"
+
 walker@^1.0.7, walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
@@ -10086,6 +10234,28 @@ web-streams-polyfill@^3.1.1, web-streams-polyfill@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
+
+web3.storage@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/web3.storage/-/web3.storage-4.4.0.tgz#c62807e6400b16eb028d93bed6d7f76a929150a8"
+  integrity sha512-I48GB+cFGfSbi47e3ZmyRX/ZUi9EcrqUylZ6FG1AU8UGErG3t4svZocaXTaUnp2zZWAtbbUFsFtD/cd9FgoVjA==
+  dependencies:
+    "@ipld/car" "^3.1.4"
+    "@web-std/blob" "^3.0.4"
+    "@web-std/fetch" "^3.0.3"
+    "@web-std/file" "^3.0.2"
+    "@web3-storage/parse-link-header" "^3.1.0"
+    browser-readablestream-to-it "^1.0.3"
+    carbites "^1.0.6"
+    cborg "^1.8.0"
+    files-from-path "^0.2.4"
+    ipfs-car "^0.7.0"
+    libp2p-crypto "^0.21.0"
+    p-retry "^4.5.0"
+    streaming-iterables "^6.2.0"
+    throttled-queue "^2.1.2"
+    uint8arrays "^3.0.0"
+    w3name "^1.0.4"
 
 webcrypto-core@^1.7.4:
   version "1.7.5"


### PR DESCRIPTION
* Added web3.storage support, swapped in for `storeData` and `getData`.
* Run `yarn build`, which replaced files in `.graphclient/`
* Removed `deleteMetadata`. Not sure this is an operation we want people to do
* Ignoring sdk for lint-staged at the moment, until we can get it actually integrated into the turbo monorepo build
* Added typed errors to SDK