### PR TITLE
feat(sdk): Add a HypercertsStorage class

### DIFF
--- a/sdk/.env.template
+++ b/sdk/.env.template
@@ -1,3 +1,2 @@
-GRAPH_URL="https://example.com"
 NFT_STORAGE_TOKEN="your-api-token"
 WEB3_STORAGE_TOKEN="your-api-token"

--- a/sdk/.graphclientrc.yml
+++ b/sdk/.graphclientrc.yml
@@ -2,7 +2,7 @@ sources:
   - name: hypercerts-dev
     handler:
       graphql:
-        endpoint: https://api.thegraph.com/subgraphs/name/bitbeckers/hypercerts-dev
+        endpoint: https://api.thegraph.com/subgraphs/name/hypercerts-admin/hypercerts-testnet
 
 documents:
   - ./src/queries/*.graphql

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -2,8 +2,18 @@
 import { validateMetaData, validateClaimData } from "./validator/index.js";
 import { formatHypercertData } from "./formatter.js";
 import { storeMetadata, storeData, getMetadata, getData } from "./operator/index.js";
+import { HypercertsStorage } from "./operator/hypercerts-storage.js";
 
-export { validateMetaData, validateClaimData, storeMetadata, storeData, getMetadata, getData, formatHypercertData };
+export {
+  validateMetaData,
+  validateClaimData,
+  storeMetadata,
+  storeData,
+  getMetadata,
+  getData,
+  formatHypercertData,
+  HypercertsStorage,
+};
 
 // Graph
 import { execute } from "./.graphclient/index.js";

--- a/sdk/src/operator/hypercerts-storage.ts
+++ b/sdk/src/operator/hypercerts-storage.ts
@@ -1,0 +1,48 @@
+// @ts-ignore
+import { NFTStorage, CIDString } from "nft.storage";
+// @ts-ignore
+import { Web3Storage } from "web3.storage";
+import {
+  defaultNftStorageClient,
+  defaultWeb3StorageClient,
+  storeMetadata,
+  getMetadata,
+  storeData,
+  getData,
+} from "./index.js";
+import { HypercertMetadata } from "../types/metadata.js";
+
+export interface HypercertsStorageConfig {
+  nftStorageToken?: string;
+  web3StorageToken?: string;
+}
+
+export class HypercertsStorage {
+  private nftStorageClient: NFTStorage;
+  private web3StorageClient: Web3Storage;
+
+  constructor(private config: HypercertsStorageConfig) {
+    this.nftStorageClient = config.nftStorageToken
+      ? new NFTStorage({ token: config.nftStorageToken })
+      : defaultNftStorageClient;
+    this.web3StorageClient = config.web3StorageToken
+      ? new Web3Storage({ token: config.web3StorageToken })
+      : defaultWeb3StorageClient;
+  }
+
+  public async storeMetadata(data: HypercertMetadata): Promise<CIDString> {
+    return await storeMetadata(data, this.nftStorageClient);
+  }
+
+  public async getMetadata(cidOrIpfsUri: string): Promise<HypercertMetadata> {
+    return await getMetadata(cidOrIpfsUri);
+  }
+
+  public async storeData(data: any): Promise<CIDString> {
+    return await storeData(data, this.web3StorageClient);
+  }
+
+  public async getData(cidOrIpfsUri: string): Promise<any> {
+    return await getData(cidOrIpfsUri, this.web3StorageClient);
+  }
+}

--- a/sdk/src/operator/index.ts
+++ b/sdk/src/operator/index.ts
@@ -16,8 +16,8 @@ export const getNftStorageGatewayUri = (cidOrIpfsUri: string) => {
   return NFT_STORAGE_IPFS_GATEWAY.replace("{cid}", getCid(cidOrIpfsUri));
 };
 
-const defaultNftStorageClient = new NFTStorage({ token: NFT_STORAGE_TOKEN });
-const defaultWeb3StorageClient = new Web3Storage({ token: WEB3_STORAGE_TOKEN });
+export const defaultNftStorageClient = new NFTStorage({ token: NFT_STORAGE_TOKEN });
+export const defaultWeb3StorageClient = new Web3Storage({ token: WEB3_STORAGE_TOKEN });
 
 /**
  * Stores NFT metadata into NFT.storage
@@ -38,7 +38,7 @@ export const storeMetadata = async (data: HypercertMetadata, targetClient?: NFTS
  * @param cidOrIpfsUri
  * @returns
  */
-export const getMetadata = async (cidOrIpfsUri: string): Promise<HypercertMetadata | null> => {
+export const getMetadata = async (cidOrIpfsUri: string): Promise<HypercertMetadata> => {
   const nftStorageGatewayLink = getNftStorageGatewayUri(cidOrIpfsUri);
   console.log(`Getting metadata ${cidOrIpfsUri} at ${nftStorageGatewayLink}`);
   return axios.get<HypercertMetadata>(nftStorageGatewayLink).then((result) => result.data);
@@ -67,7 +67,7 @@ export const storeData = async (data: any, targetClient?: Web3Storage): Promise<
  * @param cidOrIpfsUri
  * @returns
  */
-export const getData = async (cidOrIpfsUri: string, targetClient?: Web3Storage) => {
+export const getData = async (cidOrIpfsUri: string, targetClient?: Web3Storage): Promise<any> => {
   const client = targetClient ?? defaultWeb3StorageClient;
   const cid = getCid(cidOrIpfsUri);
 


### PR DESCRIPTION
* This allows us to pass in NFT.storage and web3.storage keys into a Storage class so that we don't have to rely on implicit environment variables
* Remove GRAPH_URL from .env, I don't think we're using it
* Updated the hardcoded graph URL endpoint in the codegen