### PR TITLE
fix: update defender scripts to support multiple networks

### DIFF
--- a/defender/src/auto-tasks/batch-mint-claims-from-allowlists.ts
+++ b/defender/src/auto-tasks/batch-mint-claims-from-allowlists.ts
@@ -4,9 +4,11 @@ import { createClient } from "@supabase/supabase-js";
 import * as protocol from "@hypercerts-org/hypercerts-protocol";
 const { HypercertMinterABI } = protocol;
 import fetch from "node-fetch";
+import { getNetworkConfigFromName } from "../networks";
 
 export async function handler(event: AutotaskEvent) {
   const { SUPABASE_URL, SUPABASE_SECRET_API_KEY } = event.secrets;
+  const network = getNetworkConfigFromName(event.autotaskName);
 
   const client = createClient(SUPABASE_URL, SUPABASE_SECRET_API_KEY, {
     global: {
@@ -25,7 +27,7 @@ export async function handler(event: AutotaskEvent) {
   console.log("From address", fromAddress);
 
   const tx = await ethers
-    .getDefaultProvider("goerli")
+    .getDefaultProvider(network.networkKey)
     .getTransaction(match.hash);
 
   const contractInterface = new ethers.utils.Interface(HypercertMinterABI);
@@ -46,7 +48,7 @@ export async function handler(event: AutotaskEvent) {
   console.log("Formatted claim ids", formattedClaimIds);
 
   const deleteResult = await client
-    .from("allowlistCache")
+    .from(network.supabaseTableName)
     .delete()
     .eq("address", fromAddress)
     .in("claimId", formattedClaimIds)

--- a/defender/src/auto-tasks/mint-claim-from-allowlist.ts
+++ b/defender/src/auto-tasks/mint-claim-from-allowlist.ts
@@ -4,9 +4,11 @@ import { createClient } from "@supabase/supabase-js";
 import * as protocol from "@hypercerts-org/hypercerts-protocol";
 const { HypercertMinterABI } = protocol;
 import fetch from "node-fetch";
+import { getNetworkConfigFromName } from "../networks";
 
 export async function handler(event: AutotaskEvent) {
   const { SUPABASE_URL, SUPABASE_SECRET_API_KEY } = event.secrets;
+  const network = getNetworkConfigFromName(event.autotaskName);
 
   const client = createClient(SUPABASE_URL, SUPABASE_SECRET_API_KEY, {
     global: {
@@ -33,7 +35,7 @@ export async function handler(event: AutotaskEvent) {
   const contractAddress = match.matchedAddresses[0];
 
   const tx = await ethers
-    .getDefaultProvider("goerli")
+    .getDefaultProvider(network.networkKey)
     .getTransaction(match.hash);
 
   const contractInterface = new ethers.utils.Interface(HypercertMinterABI);
@@ -48,7 +50,7 @@ export async function handler(event: AutotaskEvent) {
     .toLowerCase()}`;
 
   const deleteResult = await client
-    .from("allowlistCache")
+    .from(network.supabaseTableName)
     .delete()
     .eq("address", fromAddress)
     .eq("claimId", formattedClaimId)

--- a/defender/src/config.ts
+++ b/defender/src/config.ts
@@ -1,22 +1,34 @@
 import * as dotenv from "dotenv";
+import { NetworkConfig, NETWORKS } from "./networks.js";
+
 dotenv.config();
 
-export const requireEnv = (value: string | undefined, identifier: string) => {
+const requireEnv = (value: string | undefined, identifier: string) => {
   if (!value) {
     throw new Error(`Required env var ${identifier} does not exist`);
   }
   return value;
 };
 
-export const apiKey = requireEnv(
-  process.env.OPENZEPPELIN_DEFENDER_ADMIN_API_KEY,
-  "OPENZEPPELIN_DEFENDER_ADMIN_API_KEY",
-);
-export const apiSecret = requireEnv(
-  process.env.OPENZEPPELIN_DEFENDER_ADMIN_API_SECRET,
-  "OPENZEPPELIN_DEFENDER_ADMIN_API_SECRET",
-);
-export const contractAddress = requireEnv(
-  process.env.CONTRACT_ADDRESS,
-  "CONTRACT_ADDRESS",
-);
+interface Config {
+  networks: NetworkConfig[];
+  credentials: {
+    apiKey: string;
+    apiSecret: string;
+  };
+}
+
+const config: Config = {
+  networks: NETWORKS,
+  credentials: {
+    apiKey: requireEnv(
+      process.env.OPENZEPPELIN_DEFENDER_ADMIN_API_KEY,
+      "OPENZEPPELIN_DEFENDER_ADMIN_API_KEY",
+    ),
+    apiSecret: requireEnv(
+      process.env.OPENZEPPELIN_DEFENDER_ADMIN_API_SECRET,
+      "OPENZEPPELIN_DEFENDER_ADMIN_API_SECRET",
+    ),
+  },
+};
+export default config;

--- a/defender/src/create-autotask.ts
+++ b/defender/src/create-autotask.ts
@@ -1,15 +1,10 @@
 import { AutotaskClient } from "defender-autotask-client";
-import { apiKey, apiSecret } from "./config.js";
 import { SentinelTrigger } from "defender-autotask-client/lib/models/autotask.js";
-
-const credentials = {
-  apiKey,
-  apiSecret,
-};
+import config from "./config.js";
 
 export const createTask = async (name: string, file: string) => {
-  const client = new AutotaskClient(credentials);
-  const config = {
+  const client = new AutotaskClient(config.credentials);
+  const taskConfig = {
     name,
     encodedZippedCode: await client.getEncodedZippedCodeFromFolder(
       `./build/relay/${file}`,
@@ -19,7 +14,7 @@ export const createTask = async (name: string, file: string) => {
   };
 
   return await client
-    .create(config)
+    .create(taskConfig)
     .then((res) => {
       console.log("Created autotask", name, "with id", res.autotaskId);
       return res;

--- a/defender/src/create-sentinel.ts
+++ b/defender/src/create-sentinel.ts
@@ -5,35 +5,30 @@ import {
   EventCondition,
   FunctionCondition,
 } from "defender-sentinel-client/lib/models/subscriber.js";
-import { apiKey, apiSecret } from "./config.js";
-
-const credentials = {
-  apiKey: apiKey,
-  apiSecret: apiSecret,
-};
-
-const client = new SentinelClient(credentials);
+import config from "./config.js";
+import { NetworkConfig } from "./networks.js";
 
 export const createSentinel = async ({
-  address,
   name,
+  network,
   autotaskID,
   functionConditions = [],
   eventConditions = [],
 }: {
   name: string;
-  address: string;
+  network: NetworkConfig;
   autotaskID: string;
   eventConditions?: EventCondition[];
   functionConditions?: FunctionCondition[];
 }) => {
+  const client = new SentinelClient(config.credentials);
   await client
     .create({
       type: "BLOCK",
-      network: "goerli",
+      network: network.networkKey,
       confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
       name,
-      addresses: [address],
+      addresses: [network.contractAddress],
       abi: JSON.stringify(HypercertMinterABI),
       paused: false,
       eventConditions,
@@ -47,7 +42,7 @@ export const createSentinel = async ({
         `Created sentinel`,
         res.name,
         "- monitoring address",
-        address,
+        network.contractAddress,
         "- linked to autotask",
         autotaskID,
       );

--- a/defender/src/errors.ts
+++ b/defender/src/errors.ts
@@ -1,0 +1,9 @@
+/**
+ * Error interfacing with OpenZeppelin API
+ */
+export class ApiError extends Error {}
+
+/**
+ * Misconfigured. Check your environment variables or `src/config.ts`
+ */
+export class ConfigError extends Error {}

--- a/defender/src/networks.ts
+++ b/defender/src/networks.ts
@@ -1,0 +1,46 @@
+import { Network } from "defender-base-client";
+
+export interface NetworkConfig {
+  networkKey: Network;
+  contractAddress: string;
+  supabaseTableName: string;
+}
+
+export const NETWORKS: NetworkConfig[] = [
+  {
+    networkKey: "goerli",
+    contractAddress: "0x822F17A9A5EeCFd66dBAFf7946a8071C265D1d07",
+    supabaseTableName: "goerli-allowlistCache",
+  },
+  {
+    networkKey: "optimism",
+    contractAddress: "0x822F17A9A5EeCFd66dBAFf7946a8071C265D1d07",
+    supabaseTableName: "optimism-allowlistCache",
+  },
+];
+
+/**
+ * We'll use this to encode the network name into the Sentinel/Autotask name
+ * We'll then subsequently use `getNetworkConfigFromName`
+ * to extract the network name from within the Autotask
+ * @param network
+ * @param name - name pre-encoding
+ * @returns
+ */
+export const encodeName = (network: NetworkConfig, name: string) =>
+  `[${network.networkKey}] ${name}`;
+
+/**
+ * From an Autotask name, deduce which NetworkConfig we're using
+ * @param name - name post-encoding
+ */
+export const getNetworkConfigFromName = (
+  name: string,
+): NetworkConfig | undefined => {
+  for (let i = 0; i < NETWORKS.length; i++) {
+    const network = NETWORKS[i];
+    if (name.includes(`[${network.networkKey}]`)) {
+      return network;
+    }
+  }
+};

--- a/defender/src/reset.ts
+++ b/defender/src/reset.ts
@@ -1,0 +1,24 @@
+import { AutotaskClient } from "defender-autotask-client";
+import { SentinelClient } from "defender-sentinel-client";
+import config from "./config.js";
+
+export const reset = async () => {
+  const autotaskClient = new AutotaskClient(config.credentials);
+  const sentinelClient = new SentinelClient(config.credentials);
+
+  // Remove all old auto tasks and sentinels
+  const oldAutoTasks = await autotaskClient.list();
+  const oldSentinels = await sentinelClient.list();
+  return await Promise.all([
+    ...oldAutoTasks.items.map((x) =>
+      autotaskClient.delete(x.autotaskId).then((res) => {
+        console.log(res.message);
+      }),
+    ),
+    ...oldSentinels.items.map((x) =>
+      sentinelClient.delete(x.subscriberId).then((res) => {
+        console.log(res.message);
+      }),
+    ),
+  ]);
+};

--- a/defender/tsconfig.json
+++ b/defender/tsconfig.json
@@ -11,13 +11,13 @@
     "forceConsistentCasingInFileNames": true,
     "lib": ["es6"],
     "module": "ESNext",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "node",
     "noImplicitAny": true,
     "removeComments": true,
     "resolveJsonModule": true,
     "sourceMap": false,
     "strict": false,
-    "target": "es6",
+    "target": "es6"
   },
   "exclude": ["node_modules"],
   "include": ["src/**/*"]


### PR DESCRIPTION
* Added custom error types
* Added network configuration in `defender/src/networks.ts`
* Abstract out the reset code into a separate file `reset.ts`
* Encode the network name in the autotask name, and use that to retrieve configurations
* Created a config wrapper
* Run through the setup script for each network defined in config
* Changed module resolution to `node` so that webpack can load utility functions