### PR TITLE
fix: Defender scripts

### DIFF
--- a/defender/package.json
+++ b/defender/package.json
@@ -12,7 +12,6 @@
     "setup": "NODE_OPTIONS='--no-warnings --loader ts-node/esm' npx ts-node src/setup.ts"
   },
   "dependencies": {
-    "@hypercerts-org/hypercerts-protocol": "^0.0.10",
     "@openzeppelin/merkle-tree": "^1.0.2",
     "@supabase/supabase-js": "^2.4.1",
     "axios": "^1.2.6",

--- a/defender/src/HypercertMinterABI.ts
+++ b/defender/src/HypercertMinterABI.ts
@@ -1,0 +1,1117 @@
+/**
+ * This is used both with the setup scripts as well as the autotasks.
+ * The autotasks run within a restricted environment, so difficult to
+ * import directly from hypercerts-sdk
+ */
+export const abi = `[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyClaimed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ArraySize",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DoesNotExist",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DuplicateEntry",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "Invalid",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotApprovedOrOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TransfersNotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TypeMismatch",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "AdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenID",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "root",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AllowlistCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "claimIDs",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "fromTokenIDs",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "toTokenIDs",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "values",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "BatchValueTransfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "beacon",
+        "type": "address"
+      }
+    ],
+    "name": "BeaconUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "claimID",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "uri",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUnits",
+        "type": "uint256"
+      }
+    ],
+    "name": "ClaimStored",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenID",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "leaf",
+        "type": "bytes32"
+      }
+    ],
+    "name": "LeafClaimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "values",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "TransferBatch",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "TransferSingle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "value",
+        "type": "string"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "URI",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "claimID",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fromTokenID",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "toTokenID",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValueTransfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "__SemiFungible1155_init",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "accounts",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "balanceOfBatch",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32[][]",
+        "name": "proofs",
+        "type": "bytes32[][]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "claimIDs",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "units",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "batchMintClaimsFromAllowlists",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "values",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "burnBatch",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenID",
+        "type": "uint256"
+      }
+    ],
+    "name": "burnFraction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "units",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "merkleRoot",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      },
+      {
+        "internalType": "enum IHypercertToken.TransferRestrictions",
+        "name": "restrictions",
+        "type": "uint8"
+      }
+    ],
+    "name": "createAllowlist",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "hasBeenClaimed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "claimID",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "leaf",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isAllowedToClaim",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isAllowed",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_fractionIDs",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "mergeFractions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "units",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      },
+      {
+        "internalType": "enum IHypercertToken.TransferRestrictions",
+        "name": "restrictions",
+        "type": "uint8"
+      }
+    ],
+    "name": "mintClaim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "proof",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "claimID",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "units",
+        "type": "uint256"
+      }
+    ],
+    "name": "mintClaimFromAllowlist",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "units",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "fractions",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      },
+      {
+        "internalType": "enum IHypercertToken.TransferRestrictions",
+        "name": "restrictions",
+        "type": "uint8"
+      }
+    ],
+    "name": "mintClaimWithFractions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenID",
+        "type": "uint256"
+      }
+    ],
+    "name": "ownerOf",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxiableUUID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenID",
+        "type": "uint256"
+      }
+    ],
+    "name": "readTransferRestriction",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeBatchTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenID",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_newFractions",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "splitFraction",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenID",
+        "type": "uint256"
+      }
+    ],
+    "name": "unitsOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "units",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenID",
+        "type": "uint256"
+      }
+    ],
+    "name": "unitsOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "units",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenID",
+        "type": "uint256"
+      }
+    ],
+    "name": "uri",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]`;

--- a/defender/src/auto-tasks/batch-mint-claims-from-allowlists.ts
+++ b/defender/src/auto-tasks/batch-mint-claims-from-allowlists.ts
@@ -1,15 +1,23 @@
 import { ethers } from "ethers";
-import { AutotaskEvent, SentinelTriggerEvent } from "defender-autotask-utils";
+import { AutotaskEvent, BlockTriggerEvent } from "defender-autotask-utils";
 import { createClient } from "@supabase/supabase-js";
-import * as protocol from "@hypercerts-org/hypercerts-protocol";
-const { HypercertMinterABI } = protocol;
 import fetch from "node-fetch";
 import { getNetworkConfigFromName } from "../networks";
+import { MissingDataError, NotImplementedError } from "../errors";
+import { abi } from "../HypercertMinterABI";
 
 export async function handler(event: AutotaskEvent) {
-  const { SUPABASE_URL, SUPABASE_SECRET_API_KEY } = event.secrets;
+  console.log(
+    "Event: ",
+    JSON.stringify(
+      { ...event, secrets: "HIDDEN", credentials: "HIDDEN" },
+      null,
+      2,
+    ),
+  );
   const network = getNetworkConfigFromName(event.autotaskName);
-
+  const { SUPABASE_URL, SUPABASE_SECRET_API_KEY } = event.secrets;
+  const ALCHEMY_KEY = event.secrets[network.alchemyKeyEnvName];
   const client = createClient(SUPABASE_URL, SUPABASE_SECRET_API_KEY, {
     global: {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -17,31 +25,35 @@ export async function handler(event: AutotaskEvent) {
       fetch: (...args) => fetch(...args),
     },
   });
-
-  console.log("Event", event);
-  const match = event.request.body as SentinelTriggerEvent;
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const fromAddress = match.transaction.from;
+  const body = event.request.body;
+  if (!("type" in body) || body.type !== "BLOCK") {
+    throw new NotImplementedError("Event body is not a BlockTriggerEvent");
+  }
+  const blockTriggerEvent = body as BlockTriggerEvent;
+  const contractAddress = blockTriggerEvent.matchedAddresses[0];
+  const fromAddress = blockTriggerEvent.transaction.from;
+  if (!contractAddress) {
+    throw new MissingDataError(`body.matchedAddresses is missing`);
+  } else if (!fromAddress) {
+    throw new MissingDataError(`body.transaction.from is missing`);
+  }
+  console.log("Contract address", contractAddress);
   console.log("From address", fromAddress);
 
-  const tx = await ethers
-    .getDefaultProvider(network.networkKey)
-    .getTransaction(match.hash);
-
-  const contractInterface = new ethers.utils.Interface(HypercertMinterABI);
+  const provider = new ethers.providers.AlchemyProvider(
+    network.networkKey,
+    ALCHEMY_KEY,
+  );
+  const tx = await provider.getTransaction(blockTriggerEvent.hash);
+  const contractInterface = new ethers.utils.Interface(abi);
   const decodedData = contractInterface.parseTransaction({
     data: tx.data,
     value: tx.value,
   });
 
+  console.log("Transaction: ", JSON.stringify(decodedData, null, 2));
   const claimIds = decodedData.args["claimIDs"] as string[];
   console.log("claimIds", claimIds);
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
-  const contractAddress = match.matchedAddresses[0];
   const formattedClaimIds = claimIds.map(
     (claimId) => `${contractAddress}-${claimId.toString().toLowerCase()}`,
   );

--- a/defender/src/auto-tasks/mint-claim-from-allowlist.ts
+++ b/defender/src/auto-tasks/mint-claim-from-allowlist.ts
@@ -1,15 +1,23 @@
 import { ethers } from "ethers";
-import { AutotaskEvent, SentinelTriggerEvent } from "defender-autotask-utils";
+import { AutotaskEvent, BlockTriggerEvent } from "defender-autotask-utils";
 import { createClient } from "@supabase/supabase-js";
-import * as protocol from "@hypercerts-org/hypercerts-protocol";
-const { HypercertMinterABI } = protocol;
 import fetch from "node-fetch";
 import { getNetworkConfigFromName } from "../networks";
+import { MissingDataError, NotImplementedError } from "../errors";
+import { abi } from "../HypercertMinterABI";
 
 export async function handler(event: AutotaskEvent) {
-  const { SUPABASE_URL, SUPABASE_SECRET_API_KEY } = event.secrets;
+  console.log(
+    "Event: ",
+    JSON.stringify(
+      { ...event, secrets: "HIDDEN", credentials: "HIDDEN" },
+      null,
+      2,
+    ),
+  );
   const network = getNetworkConfigFromName(event.autotaskName);
-
+  const { SUPABASE_URL, SUPABASE_SECRET_API_KEY } = event.secrets;
+  const ALCHEMY_KEY = event.secrets[network.alchemyKeyEnvName];
   const client = createClient(SUPABASE_URL, SUPABASE_SECRET_API_KEY, {
     global: {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -17,37 +25,38 @@ export async function handler(event: AutotaskEvent) {
       fetch: (...args) => fetch(...args),
     },
   });
-
-  const match = event.request.body as SentinelTriggerEvent;
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
-  const tokenId = match.matchReasons[0].params.tokenID as string;
-  console.log("TokenId", tokenId);
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const fromAddress = match.transaction.from;
+  const body = event.request.body;
+  if (!("type" in body) || body.type !== "BLOCK") {
+    throw new NotImplementedError("Event body is not a BlockTriggerEvent");
+  }
+  const blockTriggerEvent = body as BlockTriggerEvent;
+  const contractAddress = blockTriggerEvent.matchedAddresses[0];
+  const fromAddress = blockTriggerEvent.transaction.from;
+  if (!contractAddress) {
+    throw new MissingDataError(`body.matchedAddresses is missing`);
+  } else if (!fromAddress) {
+    throw new MissingDataError(`body.transaction.from is missing`);
+  }
+  console.log("Contract address", contractAddress);
   console.log("From address", fromAddress);
 
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
-  const contractAddress = match.matchedAddresses[0];
-
-  const tx = await ethers
-    .getDefaultProvider(network.networkKey)
-    .getTransaction(match.hash);
-
-  const contractInterface = new ethers.utils.Interface(HypercertMinterABI);
+  const provider = new ethers.providers.AlchemyProvider(
+    network.networkKey,
+    ALCHEMY_KEY,
+  );
+  const tx = await provider.getTransaction(blockTriggerEvent.hash);
+  const contractInterface = new ethers.utils.Interface(abi);
   const decodedData = contractInterface.parseTransaction({
     data: tx.data,
     value: tx.value,
   });
 
+  console.log("Transaction: ", JSON.stringify(decodedData, null, 2));
   const claimId = decodedData.args["claimID"] as string;
   const formattedClaimId = `${contractAddress}-${claimId
     .toString()
     .toLowerCase()}`;
+  console.log("Formatted claim id", formattedClaimId);
 
   const deleteResult = await client
     .from(network.supabaseTableName)

--- a/defender/src/auto-tasks/on-allowlist-created.ts
+++ b/defender/src/auto-tasks/on-allowlist-created.ts
@@ -1,12 +1,12 @@
 import axios from "axios";
-import { AutotaskEvent, SentinelTriggerEvent } from "defender-autotask-utils";
+import { AutotaskEvent, BlockTriggerEvent } from "defender-autotask-utils";
 import { ethers } from "ethers";
 import fetch from "node-fetch";
-import * as protocol from "@hypercerts-org/hypercerts-protocol";
-const { HypercertMinterABI } = protocol;
 import { StandardMerkleTree } from "@openzeppelin/merkle-tree";
 import { createClient } from "@supabase/supabase-js";
 import { getNetworkConfigFromName } from "../networks";
+import { MissingDataError, NotImplementedError } from "../errors";
+import { abi } from "../HypercertMinterABI";
 
 const getIpfsGatewayUri = (cidOrIpfsUri: string) => {
   const NFT_STORAGE_IPFS_GATEWAY = "https://nftstorage.link/ipfs/{cid}";
@@ -17,14 +17,21 @@ const getIpfsGatewayUri = (cidOrIpfsUri: string) => {
 export const getData = async (cid: string) => {
   const nftStorageGatewayLink = getIpfsGatewayUri(cid);
   console.log(`Getting metadata ${cid} at ${nftStorageGatewayLink}`);
-
   return axios.get(nftStorageGatewayLink).then((result) => result.data);
 };
 
 export async function handler(event: AutotaskEvent) {
-  const { SUPABASE_URL, SUPABASE_SECRET_API_KEY } = event.secrets;
+  console.log(
+    "Event: ",
+    JSON.stringify(
+      { ...event, secrets: "HIDDEN", credentials: "HIDDEN" },
+      null,
+      2,
+    ),
+  );
   const network = getNetworkConfigFromName(event.autotaskName);
-
+  const { SUPABASE_URL, SUPABASE_SECRET_API_KEY } = event.secrets;
+  const ALCHEMY_KEY = event.secrets[network.alchemyKeyEnvName];
   const client = createClient(SUPABASE_URL, SUPABASE_SECRET_API_KEY, {
     global: {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -32,48 +39,65 @@ export async function handler(event: AutotaskEvent) {
       fetch: (...args) => fetch(...args),
     },
   });
-
-  const match = event.request.body as SentinelTriggerEvent;
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
-  const tokenId = match.matchReasons[0].params.tokenID as string;
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  //@ts-ignore
-  const contractAddress = match.matchedAddresses[0];
-  console.log("TokenId", tokenId);
+  const body = event.request.body;
+  if (!("type" in body) || body.type !== "BLOCK") {
+    throw new NotImplementedError("Event body is not a BlockTriggerEvent");
+  }
+  const blockTriggerEvent = body as BlockTriggerEvent;
+  const contractAddress = blockTriggerEvent.matchedAddresses[0];
+  const txnLogs = blockTriggerEvent.transaction.logs;
+  if (!contractAddress) {
+    throw new MissingDataError(`body.matchedAddresses is missing`);
+  } else if (!txnLogs) {
+    throw new MissingDataError(`body.transaction.logs is missing`);
+  }
   console.log("Contract address", contractAddress);
 
-  const tx = await ethers
-    .getDefaultProvider(network.networkKey)
-    .getTransaction(match.hash);
-
-  const contractInterface = new ethers.utils.Interface(HypercertMinterABI);
+  const provider = new ethers.providers.AlchemyProvider(
+    network.networkKey,
+    ALCHEMY_KEY,
+  );
+  const tx = await provider.getTransaction(blockTriggerEvent.hash);
+  const contractInterface = new ethers.utils.Interface(abi);
   const decodedData = contractInterface.parseTransaction({
     data: tx.data,
     value: tx.value,
   });
 
-  const metaDataUri = decodedData.args["_uri"];
-  console.log("MetaDataUri", metaDataUri);
-  const metadata = await getData(metaDataUri);
-  console.log("MetaData", metadata);
-
+  console.log("Transaction: ", JSON.stringify(decodedData, null, 2));
+  const metadataUri = decodedData.args["_uri"];
+  console.log("MetadataUri", metadataUri);
+  const metadata = await getData(metadataUri);
+  console.log("Metadata", { ...metadata, image: metadata.image?.slice(0, 64) });
   if (!metadata?.allowList) {
     throw new Error(`No allowlist found`);
   }
 
-  const treeResponse = await getData(metadata.allowList);
+  const txnEvents = txnLogs.map((l) => contractInterface.parseLog(l));
+  const allowlistCreatedEvents = txnEvents.filter(
+    (e) => e.name === "AllowlistCreated",
+  );
+  console.log(
+    "AllowlistCreated Events: ",
+    JSON.stringify(allowlistCreatedEvents, null, 2),
+  );
+  if (allowlistCreatedEvents.length !== 1) {
+    throw new MissingDataError(
+      `Unexpected saw ${allowlistCreatedEvents.length} AllowlistCreated events`,
+    );
+  }
+  const tokenId = allowlistCreatedEvents[0].args["tokenID"].toString();
+  console.log("TokenId: ", tokenId);
 
+  // Get allowlist
+  const treeResponse = await getData(metadata.allowList);
   if (!treeResponse) {
     throw new Error("Could not fetch json tree dump for allowlist");
   }
-
   const tree = StandardMerkleTree.load(JSON.parse(treeResponse));
 
-  const addresses: string[] = [];
-
   // Find the proof
+  const addresses: string[] = [];
   for (const [, v] of tree.entries()) {
     addresses.push(v[0]);
   }

--- a/defender/src/create-sentinel.ts
+++ b/defender/src/create-sentinel.ts
@@ -1,12 +1,11 @@
 import { SentinelClient } from "defender-sentinel-client";
-import * as protocol from "@hypercerts-org/hypercerts-protocol";
-const { HypercertMinterABI } = protocol;
 import {
   EventCondition,
   FunctionCondition,
 } from "defender-sentinel-client/lib/models/subscriber.js";
 import config from "./config.js";
 import { NetworkConfig } from "./networks.js";
+import { abi } from "./HypercertMinterABI.js";
 
 export const createSentinel = async ({
   name,
@@ -29,7 +28,7 @@ export const createSentinel = async ({
       confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
       name,
       addresses: [network.contractAddress],
-      abi: JSON.stringify(HypercertMinterABI),
+      abi: JSON.stringify(abi),
       paused: false,
       eventConditions,
       functionConditions,

--- a/defender/src/errors.ts
+++ b/defender/src/errors.ts
@@ -7,3 +7,13 @@ export class ApiError extends Error {}
  * Misconfigured. Check your environment variables or `src/config.ts`
  */
 export class ConfigError extends Error {}
+
+/**
+ * This is a pathway that hasn't been implemented yet
+ */
+export class NotImplementedError extends Error {}
+
+/**
+ * This is a pathway that hasn't been implemented yet
+ */
+export class MissingDataError extends Error {}

--- a/defender/src/networks.ts
+++ b/defender/src/networks.ts
@@ -1,9 +1,14 @@
 import { Network } from "defender-base-client";
 
 export interface NetworkConfig {
+  // Used to identify the network for both Alchemy and OpenZeppelin Sentinel
   networkKey: Network;
+  // Contract address on the network
   contractAddress: string;
+  // Table name in Supabase
   supabaseTableName: string;
+  // the selector to retrieve the key from event.secrets in OpenZeppelin
+  alchemyKeyEnvName: string;
 }
 
 export const NETWORKS: NetworkConfig[] = [
@@ -11,11 +16,13 @@ export const NETWORKS: NetworkConfig[] = [
     networkKey: "goerli",
     contractAddress: "0x822F17A9A5EeCFd66dBAFf7946a8071C265D1d07",
     supabaseTableName: "goerli-allowlistCache",
+    alchemyKeyEnvName: "ALCHEMY_GOERLI_KEY",
   },
   {
     networkKey: "optimism",
     contractAddress: "0x822F17A9A5EeCFd66dBAFf7946a8071C265D1d07",
     supabaseTableName: "optimism-allowlistCache",
+    alchemyKeyEnvName: "ALCHEMY_OPTIMISM_KEY",
   },
 ];
 

--- a/defender/src/setup.ts
+++ b/defender/src/setup.ts
@@ -58,7 +58,7 @@ const setup = async () => {
         functionConditions: [
           {
             functionSignature:
-              "batchMintClaimsFromAllowlists(bytes32[][],uint256[],uint256[])",
+              "batchMintClaimsFromAllowlists(address,bytes32[][],uint256[],uint256[])",
           },
         ],
       });
@@ -83,7 +83,7 @@ const setup = async () => {
         functionConditions: [
           {
             functionSignature:
-              "mintClaimFromAllowlist(bytes32[],uint256,uint256)",
+              "mintClaimFromAllowlist(address,bytes32[],uint256,uint256)",
           },
         ],
       });

--- a/docs/docs/devops/deploy-proxy.md
+++ b/docs/docs/devops/deploy-proxy.md
@@ -61,19 +61,18 @@ yarn deploy:hosted
 
 Log into the [Supabase dashboard](https://app.supabase.com/).
 We store all data in a single project, but use different tables for each network.
-The table name will be prefixed by the network (e.g. `goerli-allowlistCache`).
-
+The table name should be prefixed by the network (e.g. `goerli-allowlistCache`).
 If you are deploying to a new network, create a new table. You can copy the table schema and RLS policy from another pre-existing table.
 
 If you are deploying a new proxy contract to a network for which you already have another deployment, you'll have to make a judgement call as to whether you can reuse the existing table, whether you need to clear the existing table, or create another table.
 
 #### Update the OpenZeppelin Defender scripts
 
-Modify the Defender scripts to support the new network.
+Modify the Defender scripts to support the new network in `defender/src/networks.ts`. 
 
-TODO: new file where this is stored.
+If the ABI of the contract has changed, make sure you also update `defender/src/HypercertMinterABI.ts`.
 
-The entry point for deployment is in `defender/src/setup.ts`.
+Note: The entry point for deployment is in `defender/src/setup.ts`.
 
 #### Setup the `defender/` environment
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,7 +3469,7 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@hypercerts-org/hypercerts-protocol@0.0.10", "@hypercerts-org/hypercerts-protocol@^0.0.10":
+"@hypercerts-org/hypercerts-protocol@0.0.10":
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/@hypercerts-org/hypercerts-protocol/-/hypercerts-protocol-0.0.10.tgz#a7248d1ed35257996ac2451ed0a442ef9055ab7d"
   integrity sha512-S2igvcBB5dxB+rHZnZ/9GySJj8lKmREohQDXNJC3HGX58dJPdCwS4U+QduD/neVbMM3drZedIFtVKmxbBPb+8g==


### PR DESCRIPTION
* Hardcode the HypercertMinterABI into defender due to autotask restricted environment
* Remove all dependencies on @hypercerts-org/* packages
* Better logging and data validation for debugging
* Use Alchemy provider for retrieving transaction data
* Get AllowlistCreated events from Alchemy. Not sure what happened but event.request.body.matchReasons are no longer being populated from OpenZeppelin
* More info on devops playbook