### PR TITLE
fix(sdk): getData in SDK should NOT wrapDirectory

### DIFF
--- a/sdk/docs/RELEASE.md
+++ b/sdk/docs/RELEASE.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 0.0.26
+
+* Fix `getData` to not wrapDirectory
+
 ## 0.0.25
 
 * Remove meta-minting function temporarily

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypercerts-org/hypercerts-sdk",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "SDK for hypercerts protocol",
   "repository": "git@github.com:hypercerts-org/hypercerts.git",
   "author": "Hypercerts team",

--- a/sdk/src/operator/index.ts
+++ b/sdk/src/operator/index.ts
@@ -58,7 +58,7 @@ export const storeData = async (data: any, targetClient?: Web3Storage): Promise<
   const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
   const files = [new File([blob], "data.json")];
   console.log("Storing blob of: ", data);
-  const cid = await client.put(files);
+  const cid = await client.put(files, { wrapWithDirectory: false });
   return cid;
 };
 

--- a/sdk/test/operator.test.ts
+++ b/sdk/test/operator.test.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { expect, assert } from "chai";
 import { getData, getMetadata, storeData, storeMetadata } from "../src/index.js";
 import metadata from "./res/mockMetadata.js";
@@ -28,7 +29,7 @@ const mockData = JSON.parse(`{
 
 const mockMetadataCid = "bafkreigdm2flneb4khd7eixodagst5nrndptgezrjux7gohxcngjn67x6u";
 
-const mockDataCid = "bafybeifenmt2wocehkcslpk5gfrbxviymzwgfra24unt3xgs76snqsry2i";
+const mockDataCid = "bafkreif5otrkydrrjbp532a75hkm5goefxv5rqg35d2wqm6oveht4hqto4";
 
 describe("IPFS Client", () => {
   /**
@@ -53,8 +54,13 @@ describe("IPFS Client", () => {
   });
 
   it("Smoke test - get data", async () => {
+    // Using the getter
     const data = await getData(mockDataCid);
     expect(data).to.deep.equal(mockData);
+    // Using an IPFS gateway
+    const nftStorageGatewayLink = getNftStorageGatewayUri(mockDataCid);
+    const gatewayData = await axios.get(nftStorageGatewayLink).then((result) => result.data);
+    expect(gatewayData).to.deep.equal(mockData);
   });
 
   it("Removes ipfs:// prefix if present to get CID", () => {


### PR DESCRIPTION
* wrapDirectory is default behavior, which wraps the file in a directory
* What we want is just to get the item we stored at the root