### PR TITLE
fix: add config component to Plasmic

### DIFF
--- a/frontend/components/claim-all-fractions-button.tsx
+++ b/frontend/components/claim-all-fractions-button.tsx
@@ -8,13 +8,23 @@ import {
 
 const LOCALSTORAGE_KEY = "claimAllFractionsTime";
 const DELAY = 5 * 60 * 1000; // 5 minutes
+export const claimedRecently = () => {
+  // Check if we need to wait (been less than DELAY since last claim)
+  const lastClaimStr = localStorage.getItem(LOCALSTORAGE_KEY);
+  const needToWait = lastClaimStr
+    ? Date.now() < parseInt(lastClaimStr) + DELAY
+    : false;
+  return needToWait;
+};
 
 export const ClaimAllFractionsButton = ({
-  text = "Claim all fractions",
   className,
+  text = "Claim all fractions",
+  disabled,
 }: {
-  text: string;
   className?: string;
+  text: string;
+  disabled?: boolean;
 }) => {
   const { address } = useAccountLowerCase();
 
@@ -29,15 +39,9 @@ export const ClaimAllFractionsButton = ({
     },
   });
 
-  // Check if we need to wait (been less than DELAY since last claim)
-  const lastClaimStr = localStorage.getItem(LOCALSTORAGE_KEY);
-  const needToWait = lastClaimStr
-    ? Date.now() < parseInt(lastClaimStr) + DELAY
-    : false;
-
   return (
     <Button
-      disabled={!claimIds?.length || needToWait}
+      disabled={!claimIds?.length || disabled}
       className={className}
       onClick={() => write()}
       variant="outlined"

--- a/frontend/components/config.tsx
+++ b/frontend/components/config.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { DataProvider } from "@plasmicapp/loader-nextjs";
+import { GRAPH_URL, SUPABASE_TABLE } from "../lib/config";
+
+const PLASMIC_DATA_KEY = "Config";
+
+interface ConfigData {
+  graphUrl: string;
+  supabaseTable: string;
+}
+
+export interface ConfigProps {
+  className?: string; // Plasmic CSS class
+  children?: React.ReactNode;
+}
+
+export function Config(props: ConfigProps) {
+  const { className, children } = props;
+  const data: ConfigData = {
+    graphUrl: GRAPH_URL,
+    supabaseTable: SUPABASE_TABLE,
+  };
+  return (
+    <div className={className}>
+      <DataProvider name={PLASMIC_DATA_KEY} data={data}>
+        {children}
+      </DataProvider>
+    </div>
+  );
+}

--- a/frontend/components/dapp-context.tsx
+++ b/frontend/components/dapp-context.tsx
@@ -15,10 +15,11 @@ import {
 import { mainnet, goerli, sepolia, optimism, hardhat } from "wagmi/chains";
 import { publicProvider } from "wagmi/providers/public";
 import { DataProvider } from "@plasmicapp/loader-nextjs";
-import { DEFAULT_CHAIN_ID, GRAPH_URL, SUPABASE_TABLE } from "../lib/config";
+import { DEFAULT_CHAIN_ID } from "../lib/config";
 import { ContractInteractionDialogProvider } from "./contract-interaction-dialog-context";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useAccountLowerCase } from "../hooks/account";
+import { claimedRecently } from "./claim-all-fractions-button";
 
 const DAPP_CONTEXT_NAME = "DappContext";
 
@@ -45,8 +46,7 @@ export interface DappContextData {
   defaultChainId?: string;
   chain?: Chain;
   chains?: Chain[];
-  graphUrl?: string;
-  supabaseTable?: string;
+  waitToClaim?: boolean;
 }
 
 export const DEFAULT_TEST_DATA: DappContextData = {
@@ -54,9 +54,7 @@ export const DEFAULT_TEST_DATA: DappContextData = {
   defaultChainId: "5",
   chain: goerli,
   chains: ALL_CHAINS,
-  graphUrl:
-    "https://api.thegraph.com/subgraphs/name/hypercerts-admin/hypercerts-testnet",
-  supabaseTable: "goerli-allowlistCache",
+  waitToClaim: false,
 };
 
 export interface DappContextProps {
@@ -77,6 +75,7 @@ export function DappContext(props: DappContextProps) {
     testData,
     useTestData,
   } = props;
+  const [waitToClaim, setWaitToClaim] = React.useState(false);
 
   const inEditor = React.useContext(PlasmicCanvasContext);
   const { address } = useAccountLowerCase();
@@ -89,9 +88,13 @@ export function DappContext(props: DappContextProps) {
           chain,
           chains,
           defaultChainId: DEFAULT_CHAIN_ID,
-          graphUrl: GRAPH_URL,
-          supabaseTable: SUPABASE_TABLE,
+          waitToClaim,
         };
+
+  React.useEffect(() => {
+    // Reaches into window.localStorage, so doing it within a useEffect
+    setWaitToClaim(claimedRecently());
+  });
 
   if (showIfNotConnected && !data.myAddress && notConnected) {
     return <div className={className}> {notConnected} </div>;

--- a/frontend/lib/verify-fraction-claim.ts
+++ b/frontend/lib/verify-fraction-claim.ts
@@ -16,7 +16,9 @@ export const verifyFractionClaim = async (claimId: string, address: string) => {
     throw new Error(`No allowlist found for ${claimId}`);
   }
 
-  const treeResponse = await hypercertsStorage.getData(metadata.allowList);
+  // TODO: this should be retrieved with `getData`, but it fails on res.files()
+  // Need to investigate further
+  const treeResponse = await hypercertsStorage.getMetadata(metadata.allowList);
 
   if (!treeResponse) {
     throw new Error("Could not fetch json tree dump for allowlist");

--- a/frontend/plasmic-init.ts
+++ b/frontend/plasmic-init.ts
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 import CircularProgress from "@mui/material/CircularProgress";
 import { ClientGrid } from "./components/client-grid";
 import { DEFAULT_TEST_DATA } from "./components/dapp-context";
+import { Config } from "./components/config";
 import { HypercertCreateForm } from "./components/hypercert-create";
 import {
   FormField,
@@ -78,6 +79,22 @@ PLASMIC.registerComponent(ClientGrid, {
   },
   providesData: true,
   importPath: "./components/client-grid",
+});
+
+PLASMIC.registerComponent(Config, {
+  name: "Config",
+  description: "Expose app config",
+  props: {
+    children: {
+      type: "slot",
+      defaultValue: {
+        type: "text",
+        value: "Placeholder",
+      },
+    },
+  },
+  providesData: true,
+  importPath: "./components/config",
 });
 
 PLASMIC.registerComponent(
@@ -308,7 +325,7 @@ PLASMIC.registerComponent(ClaimAllFractionsButton, {
   description: "Button that will claim all fractions upon clicking",
   props: {
     text: "string",
-    className: "string",
+    disabled: "boolean",
   },
   importPath: "./components/claim-all-fractions-button",
 });

--- a/sdk/src/operator/index.ts
+++ b/sdk/src/operator/index.ts
@@ -78,6 +78,11 @@ export const getData = async (cidOrIpfsUri: string, targetClient?: Web3Storage):
   }
 
   // Assert there's only 1 file
+  // TODO: because we are storing with `wrapDirectory: false`, this call fails
+  //  on upstream projects (e.g. frontend)
+  //  which is confusing because there's no other way to retrieve the file
+  //  doubly confusing because the unit tests work fine.
+  //  Need further investigating, but using `getMetadata` works as a workaround atm
   const files = await res.files();
   if (files.length !== 1) {
     throw new MalformedDataError(`Expected 1 file but got ${files.length}`);


### PR DESCRIPTION
* Adding a Config code component that exposes app configuration
* Expose whether we claimed recently to DappContext
* Removed the hardcoded disable in ClaimAllFractionsButton and added a disabled toggle (that can be controlled via Plasmic)
* Added some in-line commentary about why `getData` is failing in the frontend