### PR TITLE
fix: uri broken in contract

### DIFF
--- a/contracts/.openzeppelin/goerli.json
+++ b/contracts/.openzeppelin/goerli.json
@@ -4038,6 +4038,371 @@
           }
         }
       }
+    },
+    "5bd56aa108022a80651301eeed96e6ac20fea02040073a01f341a6c8b635d38e": {
+      "address": "0x396D5f1EF3aa92dDAd4DEad04388374A03BC5577",
+      "txHash": "0x7aeb34b58010a583b937bf2982f6edad84812f938131dc69f5990927d59c5730",
+      "layout": {
+        "solcVersion": "0.8.16",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "contract": "ERC1155Upgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/ERC1155Upgradeable.sol:25"
+          },
+          {
+            "label": "_operatorApprovals",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "contract": "ERC1155Upgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/ERC1155Upgradeable.sol:28"
+          },
+          {
+            "label": "_uri",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_string_storage",
+            "contract": "ERC1155Upgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/ERC1155Upgradeable.sol:31"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "ERC1155Upgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/ERC1155Upgradeable.sol:528"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1155BurnableUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/extensions/ERC1155BurnableUpgradeable.sol:52"
+          },
+          {
+            "label": "_baseURI",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_string_storage",
+            "contract": "ERC1155URIStorageUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/extensions/ERC1155URIStorageUpgradeable.sol:27"
+          },
+          {
+            "label": "_tokenURIs",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_mapping(t_uint256,t_string_storage)",
+            "contract": "ERC1155URIStorageUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/extensions/ERC1155URIStorageUpgradeable.sol:30"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC1155URIStorageUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/token/ERC1155/extensions/ERC1155URIStorageUpgradeable.sol:77"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "typeCounter",
+            "offset": 0,
+            "slot": "401",
+            "type": "t_uint256",
+            "contract": "SemiFungible1155",
+            "src": "src/SemiFungible1155.sol:27"
+          },
+          {
+            "label": "owners",
+            "offset": 0,
+            "slot": "402",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "SemiFungible1155",
+            "src": "src/SemiFungible1155.sol:38"
+          },
+          {
+            "label": "creators",
+            "offset": 0,
+            "slot": "403",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "SemiFungible1155",
+            "src": "src/SemiFungible1155.sol:41"
+          },
+          {
+            "label": "tokenValues",
+            "offset": 0,
+            "slot": "404",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "SemiFungible1155",
+            "src": "src/SemiFungible1155.sol:44"
+          },
+          {
+            "label": "maxIndex",
+            "offset": 0,
+            "slot": "405",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "SemiFungible1155",
+            "src": "src/SemiFungible1155.sol:47"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "406",
+            "type": "t_array(t_uint256)25_storage",
+            "contract": "SemiFungible1155",
+            "src": "src/SemiFungible1155.sol:433"
+          },
+          {
+            "label": "merkleRoots",
+            "offset": 0,
+            "slot": "431",
+            "type": "t_mapping(t_uint256,t_bytes32)",
+            "contract": "AllowlistMinter",
+            "src": "src/AllowlistMinter.sol:17"
+          },
+          {
+            "label": "hasBeenClaimed",
+            "offset": 0,
+            "slot": "432",
+            "type": "t_mapping(t_uint256,t_mapping(t_bytes32,t_bool))",
+            "contract": "AllowlistMinter",
+            "src": "src/AllowlistMinter.sol:18"
+          },
+          {
+            "label": "maxUnits",
+            "offset": 0,
+            "slot": "433",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "AllowlistMinter",
+            "src": "src/AllowlistMinter.sol:19"
+          },
+          {
+            "label": "minted",
+            "offset": 0,
+            "slot": "434",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "contract": "AllowlistMinter",
+            "src": "src/AllowlistMinter.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "435",
+            "type": "t_array(t_uint256)26_storage",
+            "contract": "AllowlistMinter",
+            "src": "src/AllowlistMinter.sol:69"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "461",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "462",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "lib/openzeppelin-contracts-upgradeable/contracts/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "typeRestrictions",
+            "offset": 0,
+            "slot": "511",
+            "type": "t_mapping(t_uint256,t_enum(TransferRestrictions)6765)",
+            "contract": "HypercertMinter",
+            "src": "src/HypercertMinter.sol:20"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "512",
+            "type": "t_array(t_uint256)29_storage",
+            "contract": "HypercertMinter",
+            "src": "src/HypercertMinter.sol:228"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)25_storage": {
+            "label": "uint256[25]",
+            "numberOfBytes": "800"
+          },
+          "t_array(t_uint256)26_storage": {
+            "label": "uint256[26]",
+            "numberOfBytes": "832"
+          },
+          "t_array(t_uint256)29_storage": {
+            "label": "uint256[29]",
+            "numberOfBytes": "928"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(TransferRestrictions)6765": {
+            "label": "enum IHypercertToken.TransferRestrictions",
+            "members": [
+              "AllowAll",
+              "DisallowAll",
+              "FromCreatorOnly"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bytes32)": {
+            "label": "mapping(uint256 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_enum(TransferRestrictions)6765)": {
+            "label": "mapping(uint256 => enum IHypercertToken.TransferRestrictions)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(uint256 => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(uint256 => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_string_storage)": {
+            "label": "mapping(uint256 => string)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/contracts/src/SemiFungible1155.sol
+++ b/contracts/src/SemiFungible1155.sol
@@ -368,7 +368,9 @@ contract SemiFungible1155 is
     function uri(
         uint256 tokenID
     ) public view virtual override(ERC1155Upgradeable, ERC1155URIStorageUpgradeable) returns (string memory _uri) {
-        _uri = ERC1155URIStorageUpgradeable.uri(tokenID);
+        // All tokens share the same metadata at the moment
+        uint256 typeID = getBaseType(tokenID);
+        _uri = ERC1155URIStorageUpgradeable.uri(typeID);
     }
 
     /// UTILS


### PR DESCRIPTION
* We only store the URI on the base type, so getting URI was failing on any tokenIDs.