### PR TITLE
fix: Defender not triggering on right events

### DIFF
--- a/defender/package.json
+++ b/defender/package.json
@@ -16,9 +16,9 @@
     "@supabase/supabase-js": "^2.4.1",
     "axios": "^1.2.6",
     "crypto": "^1.0.1",
-    "defender-autotask-client": "^1.38.0",
-    "defender-autotask-utils": "^1.38.0",
-    "defender-sentinel-client": "^1.38.0",
+    "defender-autotask-client": "^1.39.0",
+    "defender-autotask-utils": "^1.39.0",
+    "defender-sentinel-client": "^1.39.0",
     "dotenv": "^16.0.3",
     "node-fetch": "^3.3.0",
     "ts-node": "^10.9.1"

--- a/defender/src/create-sentinel.ts
+++ b/defender/src/create-sentinel.ts
@@ -28,7 +28,7 @@ export const createSentinel = async ({
       confirmLevel: 1, // if not set, we pick the blockwatcher for the chosen network with the lowest offset
       name,
       addresses: [network.contractAddress],
-      abi: JSON.stringify(abi),
+      abi: abi,
       paused: false,
       eventConditions,
       functionConditions,

--- a/defender/src/setup.ts
+++ b/defender/src/setup.ts
@@ -18,7 +18,7 @@ const setup = async () => {
     config.networks.map(async (network) => {
       // On allowlist created
       const autoTaskOnAllowlistCreated = await createTask(
-        encodeName(network, "add cache entries on allowlist mint"),
+        encodeName(network, "on-allowlist-created"),
         "on-allowlist-created",
       );
       if (!autoTaskOnAllowlistCreated) {
@@ -40,7 +40,7 @@ const setup = async () => {
 
       // On batch minted
       const autoTaskOnBatchMintClaimsFromAllowlists = await createTask(
-        encodeName(network, "remove cache entries on batch mint"),
+        encodeName(network, "batch-mint-claims-from-allowlists"),
         "batch-mint-claims-from-allowlists",
       );
       if (!autoTaskOnBatchMintClaimsFromAllowlists) {
@@ -65,7 +65,7 @@ const setup = async () => {
 
       // On single minted from allowlist
       const autoTaskOnMintClaimFromAllowlist = await createTask(
-        encodeName(network, "remove cache entry on mint claim from allowlist"),
+        encodeName(network, "mint-claim-from-allowlist"),
         "mint-claim-from-allowlist",
       );
       if (!autoTaskOnMintClaimFromAllowlist) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10154,28 +10154,28 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-defender-autotask-client@^1.38.0:
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/defender-autotask-client/-/defender-autotask-client-1.38.0.tgz#7158ca116ffcca7e5539d3c43b34145465008bd1"
-  integrity sha512-GiQOHhvUdvZ2ZH5QPoXbALHzqQlpNu1g1V1/s/qaAL1PXKCtIr6VRJSmYia9V6rnhwM0Etgh9T6jYmbKHXzdvg==
+defender-autotask-client@^1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/defender-autotask-client/-/defender-autotask-client-1.39.0.tgz#159135c82a9f6116835e1cdddff5671777fa60fa"
+  integrity sha512-mL8sMameNIPRlLCjPFbGxYV6+UPYzDHVwYo8QZk7KEazB70HPzTvpFZ+hKwK4H0SxTgJkyAjyiN0dWPWs2Zgyg==
   dependencies:
     axios "^0.21.2"
-    defender-base-client "1.38.0"
+    defender-base-client "1.39.0"
     dotenv "^10.0.0"
     glob "^7.1.6"
     jszip "^3.5.0"
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 
-defender-autotask-utils@^1.38.0:
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/defender-autotask-utils/-/defender-autotask-utils-1.38.0.tgz#7314260975f8f57db3a37d86203f18d6b4d7fbc5"
-  integrity sha512-2cBNgp3aNV0zqYicKto46Ou6kbLfsTBdSzDQDPkh/z6IH+wllh3o9kyuM0IY4ycuTMMoY14rHn710QhFXKv+OA==
+defender-autotask-utils@^1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/defender-autotask-utils/-/defender-autotask-utils-1.39.0.tgz#15c00c0f809e79f2ed987cbe7ba458576b12fe8a"
+  integrity sha512-pFkpD9qA+Un6hHUMa9Ooh2O+PMSBK3FpZv1/7N9Eeqix84vxV+H9h7g2rpgIbrdD5BLAaWV2mLgM/nR/xaFCPg==
 
-defender-base-client@1.38.0:
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/defender-base-client/-/defender-base-client-1.38.0.tgz#56e99214b38d41b83dc6ef584bf900fa254f0777"
-  integrity sha512-ooxjlmnPpIP7Zb4ZJkNMcZo3eijaI1FQhgdziuvfF5ggl3gOcDwaZwRoUbYUjgC5oX0Pe+wj+fp1b4S39bjB9Q==
+defender-base-client@1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/defender-base-client/-/defender-base-client-1.39.0.tgz#c6768821527b608047de903ed682267bd86b50fd"
+  integrity sha512-x5GqEL2IHwnOLEqgzlyp0qa08hWCOGLn1idY8PucTrXo6ZMQGxQtPMx8LAquBvOD4rC3EPsr2qzln00isFcr/A==
   dependencies:
     amazon-cognito-identity-js "^6.0.1"
     async-retry "^1.3.3"
@@ -10183,14 +10183,14 @@ defender-base-client@1.38.0:
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 
-defender-sentinel-client@^1.38.0:
-  version "1.38.0"
-  resolved "https://registry.yarnpkg.com/defender-sentinel-client/-/defender-sentinel-client-1.38.0.tgz#4519220de91dca838dccac37893b1687e65ccc1a"
-  integrity sha512-RFS6lrD5aJXVmLvdVaj9n6nVkko4BU3RbNMF9ozFQSJk6Rae3b/SO80fbTwt9OIHn+DaL0BWO9j3Q8zj+EJ5sQ==
+defender-sentinel-client@^1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/defender-sentinel-client/-/defender-sentinel-client-1.39.0.tgz#98345b7c319f18452b4bda7cfe5f817bf3db1a53"
+  integrity sha512-PHQHGC+j7bjjjm8GTWNhVp8xsBrl7T98lBFQKKaihMRrtpcr5catoidG7mdu5MKpb6PMrIQ6Qsisf0YhDVCRUw==
   dependencies:
     "@ethersproject/abi" "^5.6.3"
     axios "^0.21.2"
-    defender-base-client "1.38.0"
+    defender-base-client "1.39.0"
     lodash "^4.17.19"
     node-fetch "^2.6.0"
 


### PR DESCRIPTION
* Removed extra layer of JSON.stringify, which double quoted our ABI and kept the Sentinel client from properly parsing the ABI
* This led to event/function triggers not being set up properly, so the default behavior is to trigger on anything, causing failures
* Bumped client versions for defender libraries
* Simplified names