### PR TITLE
fix: fix inconsistent checkbox visual state

### DIFF
--- a/frontend/components/forms.tsx
+++ b/frontend/components/forms.tsx
@@ -384,17 +384,18 @@ export function FormDropZone(props: FormDropZoneProps) {
 export interface FormCheckboxProps {
   className?: string; // Plasmic CSS class
   fieldName?: string; // Formik field name
-  defaultChecked?: boolean; // Default checked
-  disabled?: boolean; // Disabled
 }
 
 export function FormCheckbox(props: FormCheckboxProps) {
-  const { className, fieldName, defaultChecked, disabled } = props;
+  const { className, fieldName } = props;
 
   if (!fieldName) {
     return <div>{MISSING_FIELDNAME_ERROR}</div>;
   }
 
+  return <Field type="checkbox" className={className} name={fieldName} />;
+  /**
+   * // Would have been nice to use MUI, but for some reason the visual check box is unable to stay in sync with the form data. (e.g. with initial values)
   return (
     <Field name={fieldName} className={className}>
       {({ field }: FieldProps) => (
@@ -406,4 +407,5 @@ export function FormCheckbox(props: FormCheckboxProps) {
       )}
     </Field>
   );
+  */
 }

--- a/frontend/components/hypercert-create.tsx
+++ b/frontend/components/hypercert-create.tsx
@@ -136,10 +136,7 @@ const formDataToQueryString = (values: Record<string, any>) => {
   ["impactTimeStart", "impactTimeEnd", "workTimeStart", "workTimeEnd"].forEach(
     formatDate,
   );
-  const filteredValues = _.chain(values)
-    .pickBy()
-    .omit(["agreeContributorsConsent", "agreeTermsConditions"])
-    .value();
+  const filteredValues = _.chain(values).pickBy().value();
   return qs.stringify(filteredValues);
 };
 

--- a/frontend/plasmic-init.ts
+++ b/frontend/plasmic-init.ts
@@ -262,8 +262,6 @@ PLASMIC.registerComponent(FormCheckbox, {
   description: "Checkbox for forms",
   props: {
     fieldName: "string",
-    defaultChecked: "boolean",
-    disabled: "boolean",
   },
   importPath: "./components/forms",
 });


### PR DESCRIPTION
* When using MUI checkboxes with formik, the visual checked state was inconsistent with the form state. For example, if you set default initial value to true, it won't show true. This lead to a number of bugs where the checkbox was actually checked/unchecked when we didn't expect it to.
* Reverting to using the default checkbox in formik for now to avoid these issues