### PR TITLE
Handle undefined/empty values in metadata formatting

### DIFF
--- a/sdk/.graphclient/index.ts
+++ b/sdk/.graphclient/index.ts
@@ -1150,7 +1150,7 @@ export const ClaimByIdDocument = gql`
 ` as unknown as DocumentNode<ClaimByIdQuery, ClaimByIdQueryVariables>;
 export const ClaimTokensByOwnerDocument = gql`
   query ClaimTokensByOwner($owner: Bytes = "") {
-    claimTokens(where: { owner: $owner }, first: 30) {
+    claimTokens(where: { owner: $owner }) {
       chainName
       id
       owner

--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -1,8 +1,9 @@
 # Release notes
 
-## 0.0.21
+## 0.0.32
 
 - Handle empty fields in formatter to fix issue where OpenSea wouldn't index a token
+- Remove arbitrary limit value in fractions query
 
 ## 0.0.31
 

--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 0.0.21
+
+- Handle empty fields in formatter to fix issue where OpenSea wouldn't index a token
+
 ## 0.0.31
 
 - Hack around getData handler

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypercerts-org/hypercerts-sdk",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "SDK for hypercerts protocol",
   "repository": "git@github.com:hypercerts-org/hypercerts.git",
   "author": "Hypercerts team",

--- a/sdk/src/queries/fractions.graphql
+++ b/sdk/src/queries/fractions.graphql
@@ -1,5 +1,5 @@
 query ClaimTokensByOwner($owner: Bytes = "") {
-  claimTokens(where: { owner: $owner }, first: 30) {
+  claimTokens(where: { owner: $owner }) {
     chainName
     id
     owner

--- a/sdk/src/resources/schema/metadata.json
+++ b/sdk/src/resources/schema/metadata.json
@@ -51,10 +51,5 @@
     }
   },
   "additionalProperties": false,
-  "required": [
-    "name",
-    "description",
-    "image",
-    "properties"
-  ]
+  "required": ["name", "description", "image"]
 }

--- a/sdk/src/utils/formatter.ts
+++ b/sdk/src/utils/formatter.ts
@@ -1,5 +1,5 @@
-import { HypercertMetadata } from "../types/metadata.js";
 import { HypercertClaimdata } from "../types/claimdata.js";
+import { HypercertMetadata } from "../types/metadata.js";
 import { validateClaimData, validateMetaData } from "../validator/index.js";
 
 export const INDEFINITE_DATE_STRING = "indefinite";
@@ -44,10 +44,10 @@ const formatHypercertData = ({
 }: {
   name: string;
   description: string;
-  external_url: string;
+  external_url?: string;
   image: string;
   version: string;
-  properties: { trait_type: string; value: string }[];
+  properties?: { trait_type: string; value: string }[];
   impactScope: string[];
   excludedImpactScope: string[];
   workScope: string[];
@@ -104,12 +104,18 @@ const formatHypercertData = ({
   const metaData: HypercertMetadata = {
     name,
     description,
-    external_url,
     image,
     version,
-    properties,
     hypercert: claimData,
   };
+
+  if (properties && properties.length > 0) {
+    metaData.properties = properties;
+  }
+
+  if (external_url && external_url.length > 0) {
+    metaData.external_url = external_url;
+  }
 
   const { valid: metaDataValid, errors: metaDataErrors } = validateMetaData(metaData);
   if (!metaDataValid) {

--- a/sdk/test/formatter.test.ts
+++ b/sdk/test/formatter.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
-import { formatUnixTime, formatDate, INDEFINITE_DATE_STRING } from "../src/utils/formatter.js";
+
 import { formatHypercertData } from "../src/index.js";
+import { INDEFINITE_DATE_STRING, formatDate, formatUnixTime } from "../src/utils/formatter.js";
 
 type TestDataType = Parameters<typeof formatHypercertData>[0];
 const testData: Partial<TestDataType> = {
@@ -20,6 +21,10 @@ const testData: Partial<TestDataType> = {
   version: "0.0.1",
 };
 
+const testDataUndefinedProperties: Partial<TestDataType> = { ...testData, properties: undefined };
+
+const testDataUndefinedExternalURL: Partial<TestDataType> = { ...testData, external_url: undefined };
+
 describe("Format Hypercert Data test", () => {
   it("checks correct metadata", () => {
     const { valid, errors } = formatHypercertData(testData as TestDataType);
@@ -33,6 +38,20 @@ describe("Format Hypercert Data test", () => {
     expect(valid).to.be.false;
     expect(Object.keys(errors).length).to.eq(1);
     expect(data).to.be.null;
+  });
+
+  it("handles undefined properties", () => {
+    const { valid, errors, data } = formatHypercertData(testDataUndefinedProperties as TestDataType);
+    expect(valid).to.be.true;
+    expect(Object.keys(errors).length).to.eq(0);
+    expect(Object.keys(data!).find((key) => key === "properties")).to.be.undefined;
+  });
+
+  it("handles undefined external_url", () => {
+    const { valid, errors, data } = formatHypercertData(testDataUndefinedExternalURL as TestDataType);
+    expect(valid).to.be.true;
+    expect(Object.keys(errors).length).to.eq(0);
+    expect(Object.keys(data!).find((key) => key === "external_url")).to.be.undefined;
   });
 });
 


### PR DESCRIPTION
Fix for #528 
OpenSea doesn't handle empty `properties[]` and/or `external_url`. 

* Made these fields optional in the schema
* Regenerated types 
* Only add these field to metadata when they are not undefined/empty
* Added tests to SDK
* Successful [test mint](https://testnets.opensea.io/assets/goerli/0x822f17a9a5eecfd66dbaff7946a8071c265d1d07/113314028184672508333303744274778814414849
)

Fix for #540 
Not all fractions owner by a user are displayer in the front-end
* Removed arbitary 30-limit from fractions query


TODO

- [x] Update SDK release => released 0.0.32
- [ ] Update frontend app to latest SDK version