### PR TITLE
fix: accept querystrings via window.location.hash in hypercertfetcher

### DIFF
--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Set up Node.js 18
         uses: actions/setup-node@v3
         with:
-          cache: "yarn"
           node-version: "18.x"
+          cache: "yarn"
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:

--- a/frontend/components/hypercert-fetcher.tsx
+++ b/frontend/components/hypercert-fetcher.tsx
@@ -54,9 +54,17 @@ export function HypercertFetcher(props: HypercertFetcherProps) {
     spawn(
       (async () => {
         const newData: HypercertData = {};
-        const querystring = window.location.search.replace("?", "");
-        const q = qs.parse(querystring ?? "");
-        const qClaimId = q[QUERYSTRING_SELECTOR] as string;
+        const hashQueryString = window.location.hash.slice(
+          window.location.hash.startsWith("#") ? 1 : 0,
+        );
+        const searchQueryString = window.location.search.slice(
+          window.location.search.startsWith("?") ? 1 : 0,
+        );
+        const hashQuery = qs.parse(hashQueryString);
+        const searchQuery = qs.parse(searchQueryString);
+        // Take preference with the hash querystring
+        const qClaimId = (hashQuery[QUERYSTRING_SELECTOR] ??
+          searchQuery[QUERYSTRING_SELECTOR]) as string;
         const claimId = useQueryString
           ? qClaimId ?? byClaimId
           : byClaimId ?? qClaimId;


### PR DESCRIPTION
* Currently we are only using window.location.search, which gets all messed up on Fleek for some reason. Adding the option to accept query strings via hash parameters in HypercertFetcher