### PR TITLE
fix: Sentry sourcemaps

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -16,6 +16,10 @@ const nextConfig = {
     WEB3_STORAGE_TOKEN: process.env.NEXT_PUBLIC_WEB3_STORAGE_TOKEN,
   },
   productionBrowserSourceMaps: true,
+  webpack: (config) => {
+    config.resolve.fallback = { fs: false };
+    return config;
+  },
 };
 
 module.exports = nextConfig;
@@ -24,11 +28,3 @@ module.exports = withSentryConfig(
   { silent: true },
   { hideSourcemaps: false },
 );
-
-module.exports = {
-  webpack: (config) => {
-    config.resolve.fallback = { fs: false };
-
-    return config;
-  },
-};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "build": "next build && next export",
+    "build": "export SENTRY_RELEASE=`sentry-cli releases propose-version` && next build && next export",
     "start": "serve out",
     "dev": "next",
     "lint": "tsc --noEmit && next lint && yarn lint:eslint",
@@ -14,7 +14,9 @@
     "test:watch": "jest --watch",
     "preexport": "npm run build",
     "export": "next export",
-    "prestart": "npm run export"
+    "prestart": "npm run export",
+    "sentry:release": "export SENTRY_RELEASE=`sentry-cli releases propose-version` && echo $SENTRY_RELEASE",
+    "sentry:sourcemaps": "export SENTRY_RELEASE=`sentry-cli releases propose-version` && sentry-cli releases --org hypercerts --project hypercerts-dapp files $SENTRY_RELEASE upload-sourcemaps out/"
   },
   "dependencies": {
     "@apollo/client": "^3.7.4",

--- a/package.json
+++ b/package.json
@@ -27,10 +27,12 @@
     "deploy:cors-proxy": "turbo run deploy --filter=cors-proxy --parallel",
     "deploy:defender": "turbo run deploy --filter=hypercerts-defender --parallel",
     "deploy:graph": "turbo run deploy --filter=hypercerts-graph --parallel",
+    "deploy:site": "yarn build:site && yarn sentry:sourcemaps",
     "dev:cors-proxy": "turbo run dev --filter=cors-proxy --parallel",
     "dev:frontend": "turbo run dev --filter=hypercerts-frontend --parallel",
     "format:staged": "lint-staged",
     "lint": "turbo run lint",
+    "sentry:sourcemaps": "turbo run sentry:sourcemaps --filter=hypercerts-frontend",
     "serve:build": "yarn serve build",
     "test": "turbo run test",
     "prepare": "husky install"

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,7 @@
     },
     "dev": {},
     "lint": {},
+    "sentry:sourcemaps": {},
     "test": {},
     "contracts#build": {
       "inputs": ["./src/**/*.sol", "./src/**/*.ts", "./src/**/*.t.sol"],


### PR DESCRIPTION
* Fixing next.config.js, which was overwriting module.exports
* Add manual sourcemaps upload commands to package.json
* Uses `propose-version` to get the commit hash for release versioning