### PR TITLE
feat(sdk): createAllowlist using SDK

### DIFF
--- a/frontend/hooks/mintClaimAllowlist.ts
+++ b/frontend/hooks/mintClaimAllowlist.ts
@@ -11,6 +11,8 @@ import { HyperCertMinterFactory } from "@hypercerts-org/hypercerts-protocol";
 import {
   HypercertMetadata,
   HypercertMinting,
+  AllowlistEntry,
+  Allowlist,
 } from "@hypercerts-org/hypercerts-sdk";
 import { StandardMerkleTree } from "@openzeppelin/merkle-tree";
 import { BigNumber } from "ethers";
@@ -25,9 +27,7 @@ import {
 
 export const DEFAULT_ALLOWLIST_PERCENTAGE = 50;
 
-const generateAndStoreTree = async (
-  pairs: { address: string; units: number }[],
-) => {
+const generateAndStoreTree = async (pairs: Allowlist) => {
   const tuples = pairs.map((p) => [p.address, p.units]);
   const tree = StandardMerkleTree.of(tuples, ["address", "uint256"]);
   const cid = await hypercertsStorage.storeData(JSON.stringify(tree.dump()));
@@ -111,7 +111,9 @@ export const useMintClaimAllowlist = ({
             percentage: 1.0 - allowlistFraction,
           },
         ]);
-        const totalSupply = _.sum(allowlist.map((x) => x.units));
+        const totalSupply = _.sum(
+          allowlist.map((x: AllowlistEntry) => x.units),
+        );
 
         const { cid: merkleCID, root } = await generateAndStoreTree(allowlist);
         if (!merkleCID) {

--- a/frontend/hooks/mintClaimAllowlistSDK.ts
+++ b/frontend/hooks/mintClaimAllowlistSDK.ts
@@ -1,0 +1,134 @@
+import { useContractModal } from "../components/contract-interaction-dialog-context";
+import { mintInteractionLabels } from "../content/chainInteractions";
+import { useParseBlockchainError } from "../lib/parse-blockchain-error";
+import { parseAllowlistCsv } from "../lib/parsing";
+import { useAccountLowerCase } from "./account";
+import {
+  HypercertMetadata,
+  validateAllowlist,
+  TransferRestrictions,
+  Allowlist,
+  AllowlistEntry,
+} from "@hypercerts-org/hypercerts-sdk";
+import _ from "lodash";
+import { toast } from "react-toastify";
+import { useHypercertClient } from "./hypercerts-client";
+import { BigNumberish } from "ethers";
+
+export const DEFAULT_ALLOWLIST_PERCENTAGE = 50;
+
+export const useMintClaimAllowlistSDK = ({
+  onComplete,
+}: {
+  onComplete?: () => void;
+}) => {
+  const { client, isLoading } = useHypercertClient();
+
+  const stepDescriptions = {
+    validateAllowlist: "Validating allowlist",
+    uploading: "Uploading metadata to ipfs",
+    preparing: "Preparing contract write",
+    writing: "Minting hypercert on-chain",
+    complete: "Done minting",
+  };
+
+  const { address } = useAccountLowerCase();
+  const { setStep, showModal, hideModal } = useContractModal();
+  const parseError = useParseBlockchainError();
+
+  const getAndUpdateAllowlist = async (
+    allowlistUrl: string,
+    allowlistPercentage: number,
+  ): Promise<{
+    allowlist: Allowlist;
+    totalSupply: BigNumberish;
+    valid: boolean;
+    errors: any;
+  }> => {
+    const allowlistFraction =
+      (allowlistPercentage ?? DEFAULT_ALLOWLIST_PERCENTAGE) / 100.0;
+    const htmlResult = await fetch(allowlistUrl, { method: "GET" });
+    const htmlText = await htmlResult.text();
+    const allowlist: Allowlist = parseAllowlistCsv(htmlText, [
+      {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        address: address!,
+        // Creator gets the rest for now
+        percentage: 1.0 - allowlistFraction,
+      },
+    ]);
+    const totalSupply = _.sum(allowlist.map((x: AllowlistEntry) => x.units));
+
+    const { valid, errors } = validateAllowlist(allowlist, totalSupply);
+    return { allowlist, totalSupply, valid, errors };
+  };
+
+  const initializeWrite = async (
+    metaData: HypercertMetadata,
+    allowlistUrl: string,
+    allowlistPercentage: number,
+  ) => {
+    setStep("validateAllowlist");
+
+    const { allowlist, totalSupply, valid, errors } =
+      await getAndUpdateAllowlist(allowlistUrl, allowlistPercentage);
+
+    if (!valid) {
+      toast("Errors found in allowlist. Check console for errors.", {
+        type: "error",
+      });
+      console.error(errors);
+      hideModal();
+      return;
+    }
+
+    try {
+      setStep("preparing");
+
+      const tx = await client.createAllowlist(
+        allowlist,
+        metaData,
+        totalSupply,
+        TransferRestrictions.FromCreatorOnly,
+      );
+      setStep("writing");
+
+      const receipt = await tx.wait();
+      if (receipt.status === 0) {
+        toast("Minting failed", {
+          type: "error",
+        });
+        console.error(receipt);
+      }
+      if (receipt.status === 1) {
+        toast(mintInteractionLabels.toastSuccess, { type: "success" });
+
+        setStep("complete");
+        onComplete?.();
+      }
+    } catch (error) {
+      toast(parseError(error, mintInteractionLabels.toastError), {
+        type: "error",
+      });
+      console.error(error);
+    } finally {
+      hideModal();
+    }
+  };
+
+  return {
+    write: async ({
+      metaData,
+      allowlistUrl,
+      allowlistPercentage,
+    }: {
+      metaData: HypercertMetadata;
+      allowlistUrl: string;
+      allowlistPercentage: number;
+    }) => {
+      showModal({ stepDescriptions });
+      await initializeWrite(metaData, allowlistUrl, allowlistPercentage);
+    },
+    readOnly: isLoading || !client || client.readonly,
+  };
+};

--- a/frontend/hooks/mintClaimAllowlistSDK.ts
+++ b/frontend/hooks/mintClaimAllowlistSDK.ts
@@ -49,18 +49,22 @@ export const useMintClaimAllowlistSDK = ({
       (allowlistPercentage ?? DEFAULT_ALLOWLIST_PERCENTAGE) / 100.0;
     const htmlResult = await fetch(allowlistUrl, { method: "GET" });
     const htmlText = await htmlResult.text();
-    const allowlist: Allowlist = parseAllowlistCsv(htmlText, [
-      {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        address: address!,
-        // Creator gets the rest for now
-        percentage: 1.0 - allowlistFraction,
-      },
-    ]);
-    const totalSupply = _.sum(allowlist.map((x: AllowlistEntry) => x.units));
+    try {
+      const allowlist: Allowlist = parseAllowlistCsv(htmlText, [
+        {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          address: address!,
+          // Creator gets the rest for now
+          percentage: 1.0 - allowlistFraction,
+        },
+      ]);
+      const totalSupply = _.sum(allowlist.map((x: AllowlistEntry) => x.units));
 
-    const { valid, errors } = validateAllowlist(allowlist, totalSupply);
-    return { allowlist, totalSupply, valid, errors };
+      const { valid, errors } = validateAllowlist(allowlist, totalSupply);
+      return { allowlist, totalSupply, valid, errors };
+    } catch (error) {
+      return { allowlist: [], totalSupply: 0, valid: false, errors: error };
+    }
   };
 
   const initializeWrite = async (

--- a/frontend/hooks/mintClaimAllowlistSDK.ts
+++ b/frontend/hooks/mintClaimAllowlistSDK.ts
@@ -61,6 +61,8 @@ export const useMintClaimAllowlistSDK = ({
       const totalSupply = _.sum(allowlist.map((x: AllowlistEntry) => x.units));
 
       const { valid, errors } = validateAllowlist(allowlist, totalSupply);
+
+      console.log(valid, errors);
       return { allowlist, totalSupply, valid, errors };
     } catch (error) {
       return { allowlist: [], totalSupply: 0, valid: false, errors: error };
@@ -81,7 +83,9 @@ export const useMintClaimAllowlistSDK = ({
       toast("Errors found in allowlist. Check console for errors.", {
         type: "error",
       });
-      console.error(errors);
+      for (const error of errors) {
+        console.error(error);
+      }
       hideModal();
       return;
     }

--- a/frontend/lib/parsing.ts
+++ b/frontend/lib/parsing.ts
@@ -1,3 +1,4 @@
+import { Allowlist } from "@hypercerts-org/hypercerts-sdk";
 import { assertNever } from "./common";
 import { InvalidDataError, OutOfBoundsError } from "./errors";
 import { isAddress } from "ethers/lib/utils";
@@ -16,7 +17,7 @@ export function parseAllowlistCsv(
     address: string;
     percentage: number;
   }[] = [],
-): { address: string; units: number }[] {
+): Allowlist {
   // Parse CSV
   const { data: rawData, errors } = Papa.parse(csv, {
     header: true,
@@ -54,14 +55,14 @@ export function parseAllowlistCsv(
   const csvTotalPercentage = 1.0 - addTotalPercentage;
   const totalSupply = csvTotalSupply / csvTotalPercentage;
   const data = csvData.concat(
-    add.map(x => ({
+    add.map((x) => ({
       address: x.address.trim().toLowerCase(),
       units: Math.floor(totalSupply * x.percentage),
     })),
   );
   // Deduplicate
-  const groups = _.groupBy(data, x => x.address);
-  const addressToUnits = _.mapValues(groups, x =>
+  const groups = _.groupBy(data, (x) => x.address);
+  const addressToUnits = _.mapValues(groups, (x) =>
     x.reduce((accum, curr) => accum + curr.units, 0),
   );
   const result = _.toPairs(addressToUnits).map(([address, units]) => ({
@@ -90,16 +91,16 @@ export const parseListFromString = (
     // Split on either new lines or commas
     .split(/[,\n]/)
     // Cleanup
-    .map(i => i.trim())
+    .map((i) => i.trim())
     // Filter out non-truthy values
-    .filter(i => !!i);
+    .filter((i) => !!i);
   if (opts?.lowercase) {
     switch (opts.lowercase) {
       case "all":
-        list = list.map(x => x.toLowerCase());
+        list = list.map((x) => x.toLowerCase());
         break;
       case "addresses":
-        list = list.map(x => (isAddress(x) ? x.toLowerCase() : x));
+        list = list.map((x) => (isAddress(x) ? x.toLowerCase() : x));
         break;
       default:
         assertNever(opts.lowercase);

--- a/frontend/lib/parsing.ts
+++ b/frontend/lib/parsing.ts
@@ -24,8 +24,8 @@ export function parseAllowlistCsv(
     skipEmptyLines: true,
   });
   if (errors.length > 0) {
-    console.warn("Warnings parsing allowlist:", errors);
-    // TODO: should this throw an exception? Or should we be more tolerant?
+    console.error("Errors parsing allowlist:", errors);
+    throw new InvalidDataError("Errors parsing allowlist");
   }
   // Get the addresses and units from the CSV
   const csvData = rawData.map((row: any) => ({
@@ -43,12 +43,12 @@ export function parseAllowlistCsv(
   );
   if (addTotalPercentage < 0.0 || addTotalPercentage >= 1.0) {
     throw new OutOfBoundsError(
-      "Total percentage added must be between [0.0, 1.0)",
+      "Total percentage added must be between [0.0, 1.0]",
     );
   }
   for (let i = 0; i < add.length; i++) {
     if (add[i].percentage < 0.0 || add[i].percentage >= 1.0) {
-      throw new OutOfBoundsError("Percentage added must be between [0.0, 1.0)");
+      throw new OutOfBoundsError("Percentage added must be between [0.0, 1.0]");
     }
   }
   // Combine CSV data with manually added addresses

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -16,10 +16,10 @@ import HypercertMinterABI from "./resources/HypercertMinter.js";
 import type { HypercertClaimdata } from "./types/claimdata.js";
 import type { HypercertMetadata } from "./types/metadata.js";
 import { formatHypercertData } from "./utils/formatter.js";
-import { validateClaimData, validateMetaData } from "./validator/index.js";
-import { TransferRestrictions } from "./types/hypercerts.js";
+import { validateClaimData, validateMetaData, validateAllowlist } from "./validator/index.js";
+import { TransferRestrictions, Allowlist, AllowlistEntry } from "./types/hypercerts.js";
 
-export { validateMetaData, validateClaimData, formatHypercertData };
+export { validateMetaData, validateClaimData, validateAllowlist, formatHypercertData };
 
 export { HypercertClient };
 export { TransferRestrictions };
@@ -32,4 +32,11 @@ const { HyperCertMinterFactory } = protocol;
 
 export { HyperCertMinterFactory, HypercertMinterABI };
 
-export type { HypercertMetadata, HypercertClaimdata, ClaimByIdQuery, ClaimTokensByClaimQuery };
+export type {
+  HypercertMetadata,
+  HypercertClaimdata,
+  ClaimByIdQuery,
+  ClaimTokensByClaimQuery,
+  Allowlist,
+  AllowlistEntry,
+};

--- a/sdk/src/validator/index.ts
+++ b/sdk/src/validator/index.ts
@@ -62,8 +62,10 @@ const validateClaimData = (data: HypercertClaimdata): ValidationResult => {
 const validateAllowlist = (data: Allowlist, units: BigNumberish) => {
   const errors: Record<string, string | string[]> = {};
   const totalUnits = data.reduce((acc, curr) => acc.add(curr.units), BigNumber.from(0));
-  if (totalUnits !== units) {
-    errors["units"] = "Total units in allowlist must match total units";
+  if (!totalUnits.eq(units)) {
+    errors[
+      "units"
+    ] = `Total units in allowlist must match total units [expected: ${units}, got: ${totalUnits.toString()}]`;
   }
 
   const filteredAddresses = data.filter((entry) => !isAddress(entry.address));


### PR DESCRIPTION
* Refactored `hypercerts-create.tsx` to use SDK method
* Exposed Allowlist types via SDK
* Updated allowlist validation/parser
* Added throw on CSV parse error. The warning was blocking so upgraded it to error
* Updated allowlist validator equal checks

Works on #513 