### PR TITLE
fix: use w3link for retrieving from web3.storage

### DIFF
--- a/sdk/src/operator/hypercerts-storage.ts
+++ b/sdk/src/operator/hypercerts-storage.ts
@@ -73,6 +73,8 @@ export default class HypercertsStorage implements HypercertStorageInterface {
    * - Even though web3.storage takes a list of files, we'll assume we're only storing 1 JSON blob
    * - Because we pay for storage quotas, this data is stored best effort.
    * - If you are using our default keys, we may delete older data if we hit our storage quota
+   * TODO: replace with w3up
+   *
    * @param data
    * @param targetClient
    * @returns
@@ -92,46 +94,25 @@ export default class HypercertsStorage implements HypercertStorageInterface {
 
   /**
    * Get arbitrary data from web3.storage. Use with caution because there's no guarantee that the data will be there or safe.
-   * Get arbitrary data from web3.storage. Use with caution because there's no guarantee that the data will be there or safe.
+   * Note: confirmed with daghouse that we should use w3link to retrieve blobs
+   *
    * @param cidOrIpfsUri
    * @returns JSON data or error
    */
   public async getData(cidOrIpfsUri: string) {
-    /**
-    // Using the default web3.storage client is not working in upstream repos. Needs further testing.
-    const cid = getCid(cidOrIpfsUri);
+    const ipfsUri = this.getNftStorageGatewayUri(cidOrIpfsUri);
+    console.log(`Getting data ${cidOrIpfsUri} at ${ipfsUri}`);
 
-    // Get the data
-    const res = await this.web3StorageClient.get(cid);
-    if (!res || !res.ok) {
-      throw new FetchError(`Failed to get ${cidOrIpfsUri}`);
-    }
-
-    // Assert there's only 1 file
-    // TODO: because we are storing with `wrapDirectory: false`, this call fails
-    //  on upstream projects (e.g. frontend)
-    //  which is confusing because there's no other way to retrieve the file
-    //  doubly confusing because the unit tests work fine.
-    //  Need further investigating, but using `getMetadata` works as a workaround atm
-    const files = await res.files();
-    if (files.length !== 1) {
-      throw new MalformedDataError(`Expected 1 file but got ${files.length}`);
-    }
-    const dataStr = await files[0].text();
-    const data = JSON.parse(dataStr);
-    console.log(`Getting data ${cidOrIpfsUri}: `, data);
-    return data;
-    */
-
-    // TODO: replace current temporary fix of just using NFT.Storage IPFS gateway
-    const nftStorageGatewayLink = this.getNftStorageGatewayUri(cidOrIpfsUri);
-    console.log(`Getting data ${cidOrIpfsUri} at ${nftStorageGatewayLink}`);
-
-    return axios.get(nftStorageGatewayLink).then((result) => result.data);
+    return axios.get(ipfsUri).then((result) => result.data);
   }
 
   getNftStorageGatewayUri = (cidOrIpfsUri: string) => {
     const NFT_STORAGE_IPFS_GATEWAY = "https://nftstorage.link/ipfs/{cid}";
     return NFT_STORAGE_IPFS_GATEWAY.replace("{cid}", getCid(cidOrIpfsUri));
+  };
+
+  getW3linkGatewayUri = (cidOrIpfsUri: string) => {
+    const GATEWAY_URI = "https://w3s.link/ipfs/{cid}";
+    return GATEWAY_URI.replace("{cid}", getCid(cidOrIpfsUri));
   };
 }


### PR DESCRIPTION
* Currently we are using the NFT storage gateway, even for retrievals from web3.storage. Replacing the gateway used to w3link for web3.storage retrievals