### PR TITLE
fix: Vercel build should not use `next export`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,19 +4,19 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "build": "export SENTRY_RELEASE=`sentry-cli releases propose-version` && next build && next export",
+    "build": "export SENTRY_RELEASE=`sentry-cli releases propose-version` && next build",
     "start": "serve out",
+    "deploy": "yarn export && yarn sentry:sourcemaps",
     "dev": "next",
+    "export": "export SENTRY_RELEASE=`sentry-cli releases propose-version` && next export",
     "lint": "tsc --noEmit && next lint && yarn lint:eslint",
     "lint:eslint": "eslint --ignore-path ../.gitignore --ignore-path .gitignore --max-warnings 0 .",
     "lint:prettier": "prettier --ignore-path ../.gitignore --ignore-path .gitignore --loglevel warn --check **/*.{js,jsx,ts,tsx,sol,md,json}",
-    "test": "jest --ci",
-    "test:watch": "jest --watch",
-    "preexport": "npm run build",
-    "export": "next export",
-    "prestart": "npm run export",
+    "prestart": "yarn export",
     "sentry:release": "export SENTRY_RELEASE=`sentry-cli releases propose-version` && echo $SENTRY_RELEASE",
-    "sentry:sourcemaps": "export SENTRY_RELEASE=`sentry-cli releases propose-version` && sentry-cli releases --org hypercerts --project hypercerts-dapp files $SENTRY_RELEASE upload-sourcemaps out/"
+    "sentry:sourcemaps": "export SENTRY_RELEASE=`sentry-cli releases propose-version` && sentry-cli releases --org hypercerts --project hypercerts-dapp files $SENTRY_RELEASE upload-sourcemaps out/",
+    "test": "jest --ci",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@apollo/client": "^3.7.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "scripts": {
     "build": "turbo run build --concurrency=100%",
     "build:frontend": "turbo run build --filter=@hypercerts-org/frontend",
-    "build:site": "turbo run build --filter=@hypercerts-org/frontend --filter=@hypercerts-org/docs --filter=hypercerts-protocol && yarn copy",
     "build:contracts": "turbo run build --filter=hypercerts-protocol",
     "build:defender": "turbo run build --filter=hypercerts-defender",
     "build:graph": "turbo run build --filter=@hypercerts-org/graph",
@@ -35,12 +34,11 @@
     "deploy:cors-proxy": "turbo run deploy --filter=@hypercerts-org/cors-proxy --parallel",
     "deploy:defender": "turbo run deploy --filter=hypercerts-defender --parallel",
     "deploy:graph": "turbo run deploy --filter=@hypercerts-org/graph --parallel",
-    "deploy:site": "yarn build:site && yarn sentry:sourcemaps",
+    "deploy:site": "turbo run build --filter=@hypercerts-org/docs --filter=hypercerts-protocol && turbo run deploy --filter=@hypercerts-org/frontend && yarn copy",
     "dev:cors-proxy": "turbo run dev --filter=@hypercerts-org/cors-proxy --parallel",
     "dev:frontend": "turbo run dev --filter=@hypercerts-org/frontend --parallel",
     "format:staged": "lint-staged",
     "lint": "turbo run lint --concurrency=100%",
-    "sentry:sourcemaps": "turbo run sentry:sourcemaps --filter=@hypercerts-org/frontend",
     "serve:build": "yarn serve build",
     "test": "turbo run test --concurrency=100%",
     "prepare": "husky install"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -73,7 +73,7 @@
     "clean": "rm -rf ./dist",
     "prebuild": "yarn clean && yarn types:json && yarn graph:build:esm",
     "prepack": "yarn build",
-    "test": "NODE_OPTIONS=\"--no-warnings --experimental-vm-modules\" jest",
+    "test": "NODE_OPTIONS=\"--no-warnings --experimental-vm-modules\" jest --maxConcurrency=1",
     "types:json": "yarn run json2ts -i './src/resources/schema/' -o 'src/types' --cwd './src/resources/schema'"
   },
   "type": "module"

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,8 @@
       "outputs": ["build/**", "dist/**", "out/**", ".docusaurus", ".next/**"]
     },
     "deploy": {
-      "dependsOn": ["build", "lint", "test"]
+      "dependsOn": ["build"],
+      "outputs": ["build/**", "dist/**", "out/**", ".docusaurus", ".next/**"]
     },
     "dev": {
       "persistent": true


### PR DESCRIPTION
* yarn deploy:site is kept as a static export for Fleek and Cloudflare
* Vercel will use yarn build:frontend to deploy a full Next.js application