### PR TITLE
fix: remove `settings` and `rules` from next.config.js

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -20,14 +20,6 @@ const nextConfig = {
     config.resolve.fallback = { fs: false };
     return config;
   },
-  settings: {
-    next: {
-      rootDir: "/frontend",
-    },
-  },
-  rules: {
-    "@next/next/no-html-link-for-pages": ["/docs", "/cors-proxy"],
-  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
* These trigger a warning that they're not valid properties in the config