### PR TITLE
feat: refactor getGithubOrgFromUrl to parseGitHubUrl

### DIFF
--- a/os-observer/src/events/npm.ts
+++ b/os-observer/src/events/npm.ts
@@ -1,7 +1,7 @@
 import npmFetch from "npm-registry-fetch";
 import { EventSourceFunction, ApiReturnType } from "../utils/api.js";
 import { logger } from "../utils/logger.js";
-import { getGithubOrgFromUrl } from "../utils/parsing.js";
+import { parseGithubUrl } from "../utils/parsing.js";
 
 export interface NpmDownloadsArgs {
   name: string;
@@ -26,7 +26,10 @@ export const npmDownloads: EventSourceFunction<NpmDownloadsArgs> = async (
 
   // Check if the organization exists
   const repoUrl = pkgManifest?.repository?.url ?? "";
-  const githubOrg = getGithubOrgFromUrl(repoUrl);
+  const { owner: githubOrg } = parseGithubUrl(repoUrl) ?? {};
+  if (!githubOrg) {
+    logger.warn(`Unable to find the GitHub organization for ${name}`);
+  }
   console.log(githubOrg);
 
   // Get the latest event source pointer

--- a/os-observer/src/utils/parsing.ts
+++ b/os-observer/src/utils/parsing.ts
@@ -1,8 +1,27 @@
-export function getGithubOrgFromUrl(url: string) {
-  const regex = /\/\/github.com\/([^/]+)\/([^/]+)/g;
-  const matches = regex.exec(url);
-  if (matches) {
-    return matches[1];
+export interface ParseGitHubUrlResult {
+  owner: string;
+  name: string;
+}
+
+/**
+ * Parse a GitHub URL into its owner and name
+ * @param url
+ * @returns null if invalid input, otherwise the results
+ */
+export function parseGithubUrl(url: any): ParseGitHubUrlResult | null {
+  if (typeof url !== "string") {
+    return null;
   }
-  return null;
+
+  // eslint-disable-next-line no-useless-escape
+  const regex = /\/\/github.com\/([^/]+)\/([^\./]+)/g;
+  const matches = regex.exec(url);
+  if (!matches || matches.length < 3) {
+    return null;
+  }
+
+  return {
+    owner: matches[1],
+    name: matches[2],
+  };
 }

--- a/os-observer/test/parsing.test.ts
+++ b/os-observer/test/parsing.test.ts
@@ -1,33 +1,44 @@
-import { getGithubOrgFromUrl } from "../src/utils/parsing.js";
+import { parseGithubUrl } from "../src/utils/parsing.js";
 
 describe("parsing", () => {
   it("parses github git+https urls", () => {
     const url = "git+https://github.com/hypercerts-org/hypercerts.git";
-    const org = getGithubOrgFromUrl(url);
-    expect(org).toEqual("hypercerts-org");
+    const result = parseGithubUrl(url);
+    expect(result).not.toBeNull();
+    expect(result?.owner).toEqual("hypercerts-org");
+    expect(result?.name).toEqual("hypercerts");
   });
 
   it("parses github ssh urls", () => {
     const url = "ssh://github.com/hypercerts-org/hypercerts.git";
-    const org = getGithubOrgFromUrl(url);
-    expect(org).toEqual("hypercerts-org");
+    const result = parseGithubUrl(url);
+    expect(result).not.toBeNull();
+    expect(result?.owner).toEqual("hypercerts-org");
+    expect(result?.name).toEqual("hypercerts");
   });
 
   it("parses multi-part github ssh urls", () => {
     const url = "ssh://github.com/hypercerts-org/hypercerts/sdk";
-    const org = getGithubOrgFromUrl(url);
-    expect(org).toEqual("hypercerts-org");
+    const result = parseGithubUrl(url);
+    expect(result).not.toBeNull();
+    expect(result?.owner).toEqual("hypercerts-org");
+    expect(result?.name).toEqual("hypercerts");
   });
 
-  it("doesn't parses gitlab ssh urls", () => {
+  it("doesn't parse gitlab ssh urls", () => {
     const url = "ssh://gitlab.com/hypercerts-org/hypercerts.git";
-    const org = getGithubOrgFromUrl(url);
-    expect(org).toEqual(null);
+    const result = parseGithubUrl(url);
+    expect(result).toBeNull();
   });
 
-  it("doesn't parses malformed urls", () => {
+  it("doesn't parse malformed urls", () => {
     const url = "hypercerts-org/hypercerts.git";
-    const org = getGithubOrgFromUrl(url);
-    expect(org).toEqual(null);
+    const result = parseGithubUrl(url);
+    expect(result).toBeNull();
+  });
+
+  it("doesn't parse falsey values", () => {
+    const result = parseGithubUrl(false);
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
* want to be able to extract both the owner and name from a URL
* updated unit tests to reflect that