### PR TITLE
Create different interface to Hypercert numeric values

### DIFF
--- a/frontend/components/hypercert-fetcher.tsx
+++ b/frontend/components/hypercert-fetcher.tsx
@@ -1,13 +1,9 @@
 import { spawn } from "../lib/common";
-import {
-  ClaimByIdQuery,
-  ClaimTokensByClaimQuery,
-  HypercertMetadata,
-} from "@hypercerts-org/sdk";
 import { DataProvider } from "@plasmicapp/loader-nextjs";
 import qs from "qs";
 import React, { ReactNode } from "react";
 import { useHypercertClient } from "../hooks/hypercerts-client";
+import { Hypercert, HypercertView } from "../lib/hypercert";
 import BN from "bn.js";
 
 // The name used to pass data into the Plasmic DataProvider
@@ -33,93 +29,6 @@ export interface HypercertFetcherProps {
   useQueryString?: boolean; // Forces us to try the query string first
   byClaimId?: string; // Fetch by claimId
   byMetadataUri?: string; // Fetch by metadataUri; If both are specified, byMetadataUri will override the URI in the claim
-}
-
-export type HypercertData = ClaimByIdQuery &
-  Partial<ClaimTokensByClaimQuery> & {
-    metadata?: HypercertMetadata;
-  };
-
-export class HypercertOwnerSummary {
-  owner: string;
-  units: BN;
-  totalUnits: BN;
-
-  constructor(owner: string, units: string, totalUnits: string) {
-    this.owner = owner;
-    this.units = new BN(units);
-    this.totalUnits = new BN(totalUnits);
-  }
-
-  ownershipPercentage(precision?: number): number {
-    precision = precision ?? 2;
-    if (precision < 0) {
-      precision = 2;
-    }
-
-    // JS maximum number values are limited to 52 bits (15-17 decimal digits)
-    // and an exponent. So we set a maximum precision to 15
-    if (precision > 15) {
-      precision = 15;
-    }
-
-    const p = Math.pow(10, precision);
-    const bnP = new BN(p);
-
-    return (this.units.mul(bnP).divRound(this.totalUnits).toNumber() / p) * 100;
-  }
-}
-
-export interface HypercertView extends HypercertData {
-  getOwner(owner: string): HypercertOwnerSummary;
-  listOwners(): Array<HypercertOwnerSummary>;
-}
-
-/**
- * Hypercert is a view of a given hypercert from the SDK.
- *
- * The intent is for plasmic consumers of this object to be able to interogate
- * this view for more natural usage of the hypercerts data in plasmic.
- */
-export class Hypercert implements HypercertView {
-  private claimQueryResp: ClaimByIdQuery;
-  private claimTokensQueryResp: ClaimTokensByClaimQuery;
-  metadata?: HypercertMetadata;
-
-  constructor(
-    claimQueryResp: ClaimByIdQuery,
-    claimTokensQueryResp: ClaimTokensByClaimQuery,
-  ) {
-    this.claimQueryResp = claimQueryResp;
-    this.claimTokensQueryResp = claimTokensQueryResp;
-  }
-
-  // Access data the old way
-  get claim(): any {
-    return this.claimQueryResp.claim;
-  }
-
-  // Access data the old way
-  get claimTokens(): any {
-    return this.claimTokensQueryResp.claimTokens;
-  }
-
-  /**
-   * getOwner returns a specific owner summary
-   * @param owner
-   * @returns
-   */
-  getOwner(owner: string): HypercertOwnerSummary {
-    return new HypercertOwnerSummary(owner, "0", "0");
-  }
-
-  /**
-   * listOwners returns a list of HypercertOwnerSummary instances
-   * @returns Array<HypercertOwnerSummary>
-   */
-  listOwners(): Array<HypercertOwnerSummary> {
-    return [new HypercertOwnerSummary("hello", "0", "0")];
-  }
 }
 
 export function HypercertFetcher(props: HypercertFetcherProps) {
@@ -171,7 +80,7 @@ export function HypercertFetcher(props: HypercertFetcherProps) {
             newData.metadata = metadata;
           }
           console.log(
-            `Hypercert name='${newData.metadata?.name}' claimId=${claimId}, metadataUri=${metadataUri}: `,
+            `Hypercert name='${newData.name}' claimId=${claimId}, metadataUri=${metadataUri}: `,
             newData,
           );
           setData(newData);

--- a/frontend/lib/hypercert.test.ts
+++ b/frontend/lib/hypercert.test.ts
@@ -1,5 +1,5 @@
 import BN from "bn.js";
-import { HypercertTokens, Hypercert } from "./hypercert";
+import { HypercertTokens, FullHypercert } from "./hypercert";
 import { ClaimToken, Claim } from "@hypercerts-org/sdk";
 import { randomAddress, randomTokenID } from "./test-utils";
 
@@ -31,13 +31,13 @@ function genClaimTokens(
   return tokens;
 }
 
-function genClaim(): Claim {
+function genClaim(totalUnits: string): Claim {
   return {
     id: `0x$(randomAddress())-$(randomTokenID())`,
     creation: "",
     contract: randomAddress(),
     tokenID: randomTokenID(),
-    totalUnits: "1000",
+    totalUnits: totalUnits,
     chainName: "test",
   };
 }
@@ -98,17 +98,20 @@ describe("Hypercert", () => {
   describe("getTokenFor", () => {
     it("get token for specific addresses and calculate percentages", () => {
       const tokens = [
-        genClaimTokens(1, { owner: "test0", units: "100" }),
-        genClaimTokens(2, { owner: "test1", units: "100" }),
-        genClaimTokens(3, { owner: "test2", units: "100" }),
+        genClaimTokens(1, { owner: "deadbeef0", units: "100" }),
+        genClaimTokens(2, { owner: "deadbeef1", units: "100" }),
+        genClaimTokens(3, { owner: "deadbeef2", units: "100" }),
       ].reduce((a, c) => a.concat(c));
-      const hypercert = new Hypercert(
-        { claim: genClaim() },
+      const hypercert = new FullHypercert(
+        { claim: genClaim("1000") },
         { claimTokens: tokens },
       );
-      expect(hypercert.getTokensFor("test0").percentage()).toEqual(10);
-      expect(hypercert.getTokensFor("test1").percentage()).toEqual(20);
-      expect(hypercert.getTokensFor("test2").percentage()).toEqual(30);
+      expect(hypercert.getTokensFor("deadbeef0").percentage()).toEqual(10);
+
+      // Include test for caps in the owner address
+      expect(hypercert.getTokensFor("DEADbeef1").percentage()).toEqual(20);
+      expect(hypercert.getTokensFor("deadbeef1").percentage()).toEqual(20);
+      expect(hypercert.getTokensFor("deadbeef2").percentage()).toEqual(30);
     });
   });
 });

--- a/frontend/lib/hypercert.test.ts
+++ b/frontend/lib/hypercert.test.ts
@@ -95,18 +95,20 @@ describe("HypercertTokens", () => {
 });
 
 describe("Hypercert", () => {
-  it("get all from owner", () => {
-    const tokens = [
-      genClaimTokens(1, { owner: "test0", units: "100" }),
-      genClaimTokens(2, { owner: "test1", units: "100" }),
-      genClaimTokens(3, { owner: "test2", units: "100" }),
-    ].reduce((a, c) => a.concat(c));
-    const hypercert = new Hypercert(
-      { claim: genClaim() },
-      { claimTokens: tokens },
-    );
-    expect(hypercert.getTokensFor("test0").percentage()).toEqual(10);
-    expect(hypercert.getTokensFor("test1").percentage()).toEqual(20);
-    expect(hypercert.getTokensFor("test2").percentage()).toEqual(30);
+  describe("getTokenFor", () => {
+    it("get token for specific addresses and calculate percentages", () => {
+      const tokens = [
+        genClaimTokens(1, { owner: "test0", units: "100" }),
+        genClaimTokens(2, { owner: "test1", units: "100" }),
+        genClaimTokens(3, { owner: "test2", units: "100" }),
+      ].reduce((a, c) => a.concat(c));
+      const hypercert = new Hypercert(
+        { claim: genClaim() },
+        { claimTokens: tokens },
+      );
+      expect(hypercert.getTokensFor("test0").percentage()).toEqual(10);
+      expect(hypercert.getTokensFor("test1").percentage()).toEqual(20);
+      expect(hypercert.getTokensFor("test2").percentage()).toEqual(30);
+    });
   });
 });

--- a/frontend/lib/hypercert.test.ts
+++ b/frontend/lib/hypercert.test.ts
@@ -1,9 +1,7 @@
 import BN from "bn.js";
 import { HypercertTokens, Hypercert } from "./hypercert";
 import { ClaimToken, Claim } from "@hypercerts-org/sdk";
-import crypto from "crypto";
 import { randomAddress, randomTokenID } from "./test-utils";
-import { random } from "lodash";
 
 type GenClaimTokenOptions = {
   contract?: string;

--- a/frontend/lib/hypercert.test.ts
+++ b/frontend/lib/hypercert.test.ts
@@ -1,0 +1,114 @@
+import BN from "bn.js";
+import { HypercertTokens, Hypercert } from "./hypercert";
+import { ClaimToken, Claim } from "@hypercerts-org/sdk";
+import crypto from "crypto";
+import { randomAddress, randomTokenID } from "./test-utils";
+import { random } from "lodash";
+
+type GenClaimTokenOptions = {
+  contract?: string;
+  owner?: string;
+  chainName?: string;
+  units?: string;
+};
+
+function genClaimTokens(
+  length: number,
+  options?: GenClaimTokenOptions,
+): Array<Omit<ClaimToken, "claim">> {
+  const contract = options?.contract ?? randomAddress();
+  const tokens: Array<Omit<ClaimToken, "claim">> = [];
+  for (let i = 0; i < length; i++) {
+    const tokenID = randomTokenID();
+    const id = `0x${contract}-${tokenID}`;
+    const owner = options?.owner ?? randomAddress();
+    tokens.push({
+      id: id,
+      tokenID: tokenID,
+      owner: owner,
+      chainName: options?.chainName ?? "test",
+      units: options?.units ?? "100",
+    });
+  }
+  return tokens;
+}
+
+function genClaim(): Claim {
+  return {
+    id: `0x$(randomAddress())-$(randomTokenID())`,
+    creation: "",
+    contract: randomAddress(),
+    tokenID: randomTokenID(),
+    totalUnits: "1000",
+    chainName: "test",
+  };
+}
+
+describe("HypercertTokens", () => {
+  describe("percentage", () => {
+    // Test generator
+    const tests: Array<{
+      title: string;
+      tokenCount: number;
+      totalUnits: string;
+      tokenUnits: string;
+      precision?: number;
+      expected: number;
+    }> = [
+      {
+        title: "calculates 100% for 1 token",
+        tokenCount: 1,
+        totalUnits: "100",
+        tokenUnits: "100",
+        expected: 100,
+      },
+      {
+        title: "calculates 66.67% for 1 token",
+        tokenCount: 1,
+        totalUnits: "3",
+        tokenUnits: "2",
+        expected: 66.67,
+      },
+      {
+        title: "calculates 66.67% for 2 tokens",
+        tokenCount: 2,
+        totalUnits: "3",
+        tokenUnits: "1",
+        expected: 66.67,
+      },
+      {
+        title: "calculates 75% for 3 tokens",
+        tokenCount: 3,
+        totalUnits: "100000",
+        tokenUnits: "25000",
+        expected: 75,
+      },
+    ];
+    tests.forEach((e) => {
+      it(e.title, () => {
+        const testTokens = genClaimTokens(e.tokenCount, {
+          units: e.tokenUnits,
+        });
+        const tokens = new HypercertTokens(testTokens, new BN(e.totalUnits));
+        expect(tokens.percentage(e.precision)).toEqual(e.expected);
+      });
+    });
+  });
+});
+
+describe("Hypercert", () => {
+  it("get all from owner", () => {
+    const tokens = [
+      genClaimTokens(1, { owner: "test0", units: "100" }),
+      genClaimTokens(2, { owner: "test1", units: "100" }),
+      genClaimTokens(3, { owner: "test2", units: "100" }),
+    ].reduce((a, c) => a.concat(c));
+    const hypercert = new Hypercert(
+      { claim: genClaim() },
+      { claimTokens: tokens },
+    );
+    expect(hypercert.getTokensFor("test0").percentage()).toEqual(10);
+    expect(hypercert.getTokensFor("test1").percentage()).toEqual(20);
+    expect(hypercert.getTokensFor("test2").percentage()).toEqual(30);
+  });
+});

--- a/frontend/lib/hypercert.ts
+++ b/frontend/lib/hypercert.ts
@@ -1,0 +1,92 @@
+import {
+  ClaimByIdQuery,
+  ClaimTokensByClaimQuery,
+  HypercertMetadata,
+} from "@hypercerts-org/sdk";
+import BN from "bn.js";
+
+export class HypercertTokens {
+  totalUnits: BN;
+  tokens: ClaimTokensByClaimQuery["claimTokens"];
+
+  constructor(tokens: ClaimTokensByClaimQuery["claimTokens"], totalUnits: BN) {
+    this.totalUnits = totalUnits;
+    this.tokens = tokens;
+  }
+
+  get units(): BN {
+    return this.tokens
+      .map((t) => new BN(t.units))
+      .reduce((a, c) => a.add(c), new BN(0));
+  }
+
+  percentage(precision?: number): number {
+    precision = precision ?? 2;
+    if (precision < 0) {
+      precision = 2;
+    }
+
+    // JS maximum number values are limited to 52 bits (15-17 decimal digits)
+    // and an exponent. So we set a maximum precision to 15
+    if (precision > 15) {
+      precision = 15;
+    }
+
+    const p = Math.pow(10, precision + 2);
+    const bnP = new BN(p);
+
+    return (this.units.mul(bnP).divRound(this.totalUnits).toNumber() / p) * 100;
+  }
+}
+
+export interface HypercertView {
+  getTokensFor(owner: string): HypercertTokens;
+  metadata?: HypercertMetadata;
+  claim: ClaimByIdQuery["claim"];
+  claimTokens: ClaimTokensByClaimQuery["claimTokens"];
+  name: string;
+  totalUnits: BN;
+}
+
+/**
+ * Hypercert is a view of a given hypercert from the SDK.
+ *
+ * The intent is for plasmic consumers of this object to be able to interogate
+ * this view for more natural usage of the hypercerts data in plasmic.
+ */
+export class Hypercert implements HypercertView {
+  // Introduce no breaking change by providing the same interface as the
+  // previous HypercertData type
+  claim: ClaimByIdQuery["claim"];
+  claimTokens: ClaimTokensByClaimQuery["claimTokens"];
+  metadata?: HypercertMetadata;
+
+  constructor(
+    claimQueryResp: ClaimByIdQuery,
+    claimTokensQueryResp: ClaimTokensByClaimQuery,
+  ) {
+    this.claim = claimQueryResp.claim;
+    this.claimTokens = claimTokensQueryResp.claimTokens;
+  }
+
+  /**
+   * getTokensFor returns tokens for a specific address
+   * @param address
+   * @returns
+   */
+  getTokensFor(address: string): HypercertTokens {
+    address = address.toLocaleLowerCase();
+    return new HypercertTokens(
+      this.claimTokens.filter((t) => t.owner == address),
+      this.totalUnits,
+    );
+  }
+
+  get name(): string {
+    return this.metadata?.name ?? "";
+  }
+
+  get totalUnits(): BN {
+    return new BN(this.claim?.totalUnits ?? 1);
+  }
+}

--- a/frontend/lib/test-utils.ts
+++ b/frontend/lib/test-utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Random test utilities
+ */
+import BN from "bn.js";
+import crypto from "crypto";
+
+export function randomAddress(): string {
+  return `0x$(crypto.randomBytes(20).toString('hex'))`;
+}
+
+export function randomTokenID(): string {
+  return new BN(crypto.randomBytes(16).toString("hex"), 16).toString(10);
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,6 +71,7 @@
     "@types/react-dom": "^18.0.5",
     "@types/testing-library__jest-dom": "^5.14.5",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
+    "bn.js-typings": "^1.0.1",
     "eslint": "8.19.0",
     "eslint-config-next": "12.2.0",
     "eslint-config-prettier": "^8.6.0",

--- a/sdk/src/types/global.d.ts
+++ b/sdk/src/types/global.d.ts
@@ -1,3 +1,3 @@
-import type { ClaimByIdQuery, ClaimTokensByClaimQuery } from "../../.graphclient/index.ts";
+import type { ClaimByIdQuery, ClaimTokensByClaimQuery, ClaimToken, Claim } from "../../.graphclient/index.ts";
 
-export type { ClaimByIdQuery, ClaimTokensByClaimQuery };
+export type { ClaimByIdQuery, ClaimTokensByClaimQuery, ClaimToken, Claim };

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -13,5 +13,5 @@ export type {
   IPFSEvaluation,
   HypercertPointer,
 } from "./evaluation.js";
-export type { ClaimByIdQuery, ClaimTokensByClaimQuery } from "./global.js";
+export type { ClaimByIdQuery, ClaimTokensByClaimQuery, Claim, ClaimToken } from "./global.js";
 export type { HypercertMetadata } from "./metadata.js";

--- a/yarn.lock
+++ b/yarn.lock
@@ -8060,7 +8060,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
   integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
 
-"@types/node@^10.0.3":
+"@types/node@^10.0.3", "@types/node@^10.12.12":
   version "10.17.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
@@ -10747,6 +10747,13 @@ blockstore-datastore-adapter@^4.0.0:
     it-drain "^2.0.0"
     it-pushable "^3.1.0"
     multiformats "^10.0.1"
+
+bn.js-typings@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bn.js-typings/-/bn.js-typings-1.0.1.tgz#00faef56401850b763cee041c0728a9aaf091e7e"
+  integrity sha512-PdV3AEpI5A8mHCt3KgBobIJ+3rhoxxkRl8b0dCGDgGtJNYmN4KTPLHYq7xOSmKF1Kv06aZ5k8QhXbyG73IyhdQ==
+  dependencies:
+    "@types/node" "^10.12.12"
 
 bn.js@4.11.6:
   version "4.11.6"


### PR DESCRIPTION
Addresses #657 

Wanted to leave this draft up. Would have had this sooner but ran into some silly editor issues.

The proposed changes on this draft are a bit of a departure from what we might be doing in other parts of the code so I want to make sure people see it before I've finished everything. 

My thought was to organize this all in an object model that should hopefully become an intuitive interface for usage in plasmic. I don't remove direct access to the numeric values of the hypercert, but I am providing methods that I'd intend to be the main way to interface with data. 

So, for example: 

* To list all of the owners of a given hypercert do:`$ctx.hypercertData.listOwners()`. This will return objects that you could then use as a collection in plasmic.
  * To get the ownership percentage of each of those objects in the collection you could then do: `currentItem.ownershipPercentage(2)` which would return a percentage with a 2 decimal precision (e.g. 100.00)
* To get a specific owner's share information of a given hypercert do: `$ctx.hypercertData.getOwner($ctx.DappContext.myAddress)`. We'd have the added benefit of making some of this a tad cleaner too by simply handling `.toLowerCase()` on the input of the address in the method.

TODOs
* [x] Write some tests
* [x] Walk through with Ray how to test this on plasmic