### PR TITLE
feat: npm pagination

### DIFF
--- a/os-observer/src/utils/common.ts
+++ b/os-observer/src/utils/common.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { AssertionError, NullOrUndefinedValueError } from "./error.js";
 
 /**
@@ -37,6 +38,47 @@ export function ensure<T>(x: T | null | undefined, msg: string): T {
     );
   } else {
     return x;
+  }
+}
+
+/**
+ * Asserts that a value is a string.
+ * @param x
+ * @returns
+ */
+export function ensureString(x: any) {
+  if (_.isString(x)) {
+    return x;
+  } else {
+    throw new Error(`Expected string, but got ${typeof x}`);
+  }
+}
+
+/**
+ * Asserts that a value is a number
+ * @param x
+ * @returns
+ */
+export function ensureNumber(x: any) {
+  if (_.isNumber(x)) {
+    return x;
+  } else {
+    throw new Error(`Expected number, but got ${typeof x}`);
+  }
+}
+
+/**
+ * Asserts that a value is an array.
+ * @param x
+ * @returns
+ */
+export function ensureArray<T>(x: T | T[] | undefined): T[] {
+  if (x == null) {
+    return [];
+  } else if (Array.isArray(x)) {
+    return x;
+  } else {
+    return [x];
   }
 }
 

--- a/os-observer/src/utils/error.ts
+++ b/os-observer/src/utils/error.ts
@@ -10,6 +10,9 @@ export class AssertionError extends Error {}
 // Invalid inputs to a function
 export class InvalidInputError extends Error {}
 
+// Data is malformed
+export class MalformedDataError extends Error {}
+
 /**
  * Represents an error that doesn't need to be forwarded to Sentry.
  * These are usually errors that are the user's fault


### PR DESCRIPTION
    * Default fetch npm downloads since the beginning of npm
    * Add validation logic for basic types
    * Add recursion to keep fetching daily downloads into the past if we get
      incomplete results. Assumes that NPM will always return the newest
      dates before older dates.
    * Fix bug where date comparison should only happen on day precision
    * Turn off data checking for the first run of a package