### PR TITLE
feat: enable scheduled autocrawl jobs

### DIFF
--- a/.github/workflows/os-observer-autocrawl.yml
+++ b/.github/workflows/os-observer-autocrawl.yml
@@ -1,18 +1,11 @@
-name: os-observer
+name: os-observer-autocrawl
 
 # Trigger the workflow when:
 on:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-    inputs:
-      command:
-        description: 'Command to run'
-        required: true
-        default: 'fetch-github'
-        type: choice
-        options:
-        - "fetch-github"
-        - "fetch-opencollective" 
+  schedule:
+    # Every day at 14:00 UTC = 07:00 PDT
+    - cron: '0 14 * * *'
 
 jobs:
   fetch-data:
@@ -33,4 +26,4 @@ jobs:
       - name: Install
         run: yarn install --immutable
       - name: Run
-        run: yarn start:os-observer ${{ inputs.command }}
+        run: yarn start:os-observer runAutocrawl

--- a/.github/workflows/os-observer-manual.yml
+++ b/.github/workflows/os-observer-manual.yml
@@ -1,0 +1,41 @@
+name: os-observer-manual
+
+# Trigger the workflow when:
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      command:
+        description: 'Command to run'
+        required: true
+        default: 'npmDownloads'
+        type: choice
+        options:
+        - "npmDownloads"
+        - "githubCommits" 
+      args:
+        description: 'Arguments to pass to the command'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  fetch-data:
+    # NOTE: This name appears in GitHub's Checks API.
+    name: fetch-data
+    environment: os-observer 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Set up Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          cache: "yarn"
+          node-version: "18.x"
+      - name: Install
+        run: yarn install --immutable
+      - name: Run
+        run: yarn start:os-observer ${{ inputs.command }} ${{ inputs.args }}

--- a/os-observer/src/actions/autocrawl.ts
+++ b/os-observer/src/actions/autocrawl.ts
@@ -1,0 +1,54 @@
+import { prisma } from "../db/prisma-client.js";
+import { ApiReturnType, CommonArgs } from "../utils/api.js";
+import { normalizeToObject } from "../utils/common.js";
+import { logger } from "../utils/logger.js";
+import { FETCHER_REGISTRY } from "../cli.js";
+
+/**
+ * Entrypoint arguments
+ */
+export type RunAutocrawlArgs = CommonArgs;
+
+export async function runAutocrawl(_args: RunAutocrawlArgs): Promise<void> {
+  // Get all pointers marked for autocrawl
+  const pointers = await prisma.eventSourcePointer.findMany({
+    where: {
+      autocrawl: true,
+    },
+  });
+
+  // Iterate over pointers and call the appropriate function
+  const summarize = async (
+    queryCommand: string,
+    queryArgs: any,
+    p: Promise<ApiReturnType>,
+  ) => {
+    const result = await p;
+    return {
+      queryCommand,
+      queryArgs,
+      ...result,
+    };
+  };
+  const promises = pointers.map(async (evtSrcPtr) => {
+    const { queryCommand, queryArgs } = evtSrcPtr;
+    logger.info(
+      `Running autocrawl for ${queryCommand} with args ${JSON.stringify(
+        queryArgs,
+      )}`,
+    );
+    const action = FETCHER_REGISTRY.find((f) => f.command === queryCommand);
+    if (!action) {
+      logger.warn(`Unknown queryCommand: ${queryCommand}`);
+      return;
+    }
+    return summarize(
+      queryCommand,
+      queryArgs,
+      action.func(normalizeToObject(queryArgs)),
+    );
+  });
+
+  // Go do it
+  console.log(await Promise.all(promises));
+}

--- a/os-observer/src/cli.ts
+++ b/os-observer/src/cli.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+import { RunAutocrawlArgs, runAutocrawl } from "./actions/autocrawl.js";
 import { handleError } from "./utils/error.js";
 import { EventSourceFunction } from "./utils/api.js";
-import { GithubCommitsArgs, githubCommits } from "./events/github.js";
+import { GithubCommitsArgs, GithubCommitsInterface } from "./events/github.js";
 import { NpmDownloadsArgs, NpmDownloadsInterface } from "./events/npm.js";
 
 const callLibrary = async <Args>(
@@ -15,6 +16,10 @@ const callLibrary = async <Args>(
   console.log(result);
 };
 
+/**
+ * When adding a new fetcher, please remember to add it to both this registry and yargs
+ */
+export const FETCHER_REGISTRY = [GithubCommitsInterface, NpmDownloadsInterface];
 yargs(hideBin(process.argv))
   .option("yes", {
     type: "boolean",
@@ -26,8 +31,16 @@ yargs(hideBin(process.argv))
     describe: "Mark the query for auto-crawling",
     default: false,
   })
+  .command<RunAutocrawlArgs>(
+    "runAutocrawl",
+    "Iterate over EventSourcePointer table and update all data marked for autocrawl",
+    (yags) => {
+      yags;
+    },
+    (argv) => handleError(runAutocrawl(argv)),
+  )
   .command<GithubCommitsArgs>(
-    "githubCommits",
+    GithubCommitsInterface.command,
     "Fetch GitHub commits",
     (yags) => {
       yags
@@ -41,7 +54,7 @@ yargs(hideBin(process.argv))
         })
         .demandOption(["org", "repo"]);
     },
-    (argv) => handleError(callLibrary(githubCommits, argv)),
+    (argv) => handleError(callLibrary(GithubCommitsInterface.func, argv)),
   )
   .command<NpmDownloadsArgs>(
     NpmDownloadsInterface.command,

--- a/os-observer/src/db/prisma-client.ts
+++ b/os-observer/src/db/prisma-client.ts
@@ -5,20 +5,11 @@ import {
   ArtifactType,
   EventType,
   Prisma,
-  EventSourcePointer,
 } from "@prisma/client";
-import { assert, safeCast } from "../utils/common.js";
+import { assert, normalizeToObject } from "../utils/common.js";
 
 export const prisma = new PrismaClient();
 export { ArtifactNamespace, ArtifactType, EventType };
-
-/**
- * Return an object type that can be used for comparisons
- * @param record
- * @returns
- */
-const normalizePointer = <PointerType>(record: EventSourcePointer | null) =>
-  safeCast(_.toPlainObject(record?.pointer) as Partial<PointerType>);
 
 /**
  * Before you do any work to fetch data, use this to retrieve the EventSourcePointer
@@ -42,7 +33,7 @@ export async function getEventSourcePointer<PointerType>(
     },
   });
   // Safe because `Partial` means they're all optional props anyway
-  return normalizePointer<PointerType>(record);
+  return normalizeToObject<PointerType>(record?.pointer);
 }
 
 /**
@@ -82,7 +73,7 @@ export async function insertData<PointerType>(
     // Make sure that the pointer hasn't changed
     assert(
       _.isEqual(
-        normalizePointer<PointerType>(dbCheckEvtSrcPtr),
+        normalizeToObject<PointerType>(dbCheckEvtSrcPtr?.pointer),
         previousPointer,
       ),
       `EventSourcePointer has changed. Aborting. Expected$ ${JSON.stringify(

--- a/os-observer/src/events/github.ts
+++ b/os-observer/src/events/github.ts
@@ -1,5 +1,10 @@
 import { gql } from "graphql-request";
-import { EventSourceFunction, ApiReturnType } from "../utils/api.js";
+import {
+  EventSourceFunction,
+  ApiInterface,
+  ApiReturnType,
+  CommonArgs,
+} from "../utils/api.js";
 
 export const query = gql`
         {{
@@ -79,10 +84,12 @@ export async function main() {
 }
 */
 
-export interface GithubCommitsArgs {
-  org: string;
-  repo: string;
-}
+export type GithubCommitsArgs = Partial<
+  CommonArgs & {
+    org: string;
+    repo: string;
+  }
+>;
 
 export const githubCommits: EventSourceFunction<GithubCommitsArgs> = async (
   args: GithubCommitsArgs,
@@ -95,3 +102,9 @@ export const githubCommits: EventSourceFunction<GithubCommitsArgs> = async (
 };
 
 //main();
+
+export const GITHUB_COMMITS_COMMAND = "githubCommits";
+export const GithubCommitsInterface: ApiInterface<GithubCommitsArgs> = {
+  command: GITHUB_COMMITS_COMMAND,
+  func: githubCommits,
+};

--- a/os-observer/src/events/npm.ts
+++ b/os-observer/src/events/npm.ts
@@ -218,9 +218,11 @@ export function hasDuplicates(downloads: DayDownloads[]): boolean {
 /**
  * Entrypoint arguments
  */
-export type NpmDownloadsArgs = CommonArgs & {
-  name: string;
-};
+export type NpmDownloadsArgs = Partial<
+  CommonArgs & {
+    name: string;
+  }
+>;
 
 /**
  * Get all of the daily downloads for a package
@@ -230,6 +232,10 @@ export const npmDownloads: EventSourceFunction<NpmDownloadsArgs> = async (
   args: NpmDownloadsArgs,
 ): Promise<ApiReturnType> => {
   const { name, autocrawl } = args;
+
+  if (!name) {
+    throw new InvalidInputError("Missing required argument: name");
+  }
   logger.info(`NPM Downloads: fetching for ${name}`);
 
   // Add the organization and artifact into the database

--- a/os-observer/src/utils/common.ts
+++ b/os-observer/src/utils/common.ts
@@ -83,6 +83,14 @@ export function ensureArray<T>(x: T | T[] | undefined): T[] {
 }
 
 /**
+ * Return an object type that can be used for comparisons
+ * @param record
+ * @returns
+ */
+export const normalizeToObject = <PointerType>(record?: any) =>
+  safeCast(_.toPlainObject(record) as Partial<PointerType>);
+
+/**
  * Explicitly mark that a cast is safe.
  * e.g. `safeCast(x as string[])`.
  */


### PR DESCRIPTION
* Update the manual fetcher GitHub action with new commands and ability to specify args
* Add a scheduled GitHub action to run autocrawl every day
* Add a FETCHER_REGISTRY for convenience
* Add a runAutocrawl CLI command that will iterate over EventSourcePointer table and run any marked for autocrawl
* Move normalizeToObject to common utilities