### PR TITLE
feat: continuously deploy os-observer database migrations

### DIFF
--- a/.github/workflows/deploy-os-observer.yml
+++ b/.github/workflows/deploy-os-observer.yml
@@ -1,30 +1,23 @@
-name: os-observer-manual
+# NOTE: This name appears in GitHub's Checks API and in workflow's status badge.
+name: deploy-os-observer
 env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
 # Trigger the workflow when:
 on:
+  # A push occurs to one of the matched branches.
+  push:
+    branches:
+      - main 
+    paths:
+      - os-observer/prisma/**
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-    inputs:
-      command:
-        description: 'Command to run'
-        required: true
-        default: 'npmDownloads'
-        type: choice
-        options:
-        - "npmDownloads"
-        - "githubCommits" 
-      args:
-        description: 'Arguments to pass to the command'
-        required: false
-        default: ''
-        type: string
 
 jobs:
-  fetch-data:
+  deploy-os-observer:
     # NOTE: This name appears in GitHub's Checks API.
-    name: fetch-data
+    name: deploy-os-observer
     environment: os-observer 
     runs-on: ubuntu-latest
     steps:
@@ -39,5 +32,5 @@ jobs:
           node-version: "18.x"
       - name: Install
         run: yarn install --immutable
-      - name: Run
-        run: yarn start:os-observer ${{ inputs.command }} ${{ inputs.args }}
+      - name: Run migrations
+        run: yarn deploy:os-observer

--- a/.github/workflows/os-observer-autocrawl.yml
+++ b/.github/workflows/os-observer-autocrawl.yml
@@ -1,4 +1,6 @@
 name: os-observer-autocrawl
+env:
+  DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
 # Trigger the workflow when:
 on:

--- a/os-observer/package.json
+++ b/os-observer/package.json
@@ -22,6 +22,7 @@
     "db:migrate": "prisma migrate dev",
     "db:start": "supabase start",
     "db:stop": "supabase stop",
+    "deploy": "yarn db:migrate",
     "dev": "tsc-watch --onSuccess \"node dist/index.js\"",
     "lint": "tsc --noEmit && yarn lint:eslint && yarn lint:prettier",
     "lint:eslint": "eslint --ignore-path ../.gitignore --max-warnings 0 --cache .",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "deploy:cors-proxy": "turbo run deploy --filter=@hypercerts-org/cors-proxy --parallel",
     "deploy:defender": "turbo run deploy --filter=hypercerts-defender --parallel",
     "deploy:graph": "turbo run deploy --filter=@hypercerts-org/graph --parallel",
+    "deploy:os-observer": "turbo run deploy --filter=@hypercerts-org/os-observer --parallel",
     "deploy:site": "turbo run build --filter=@hypercerts-org/docs --filter=hypercerts-protocol && turbo run deploy --filter=@hypercerts-org/frontend && yarn copy",
     "dev:cors-proxy": "turbo run dev --filter=@hypercerts-org/cors-proxy --parallel",
     "dev:frontend": "turbo run dev --filter=@hypercerts-org/frontend --parallel",


### PR DESCRIPTION
* Add a deploy script to os-observer that just runs migrations
* Add a GitHub workflow that runs the migration on new migrations pushed to main
* Fix other os-observer workflows to correctly pipe the DATABASE_URL