### PR TITLE
Fixes formatting issues

### DIFF
--- a/frontend/components/zuzalu-hypercert-treemap.tsx
+++ b/frontend/components/zuzalu-hypercert-treemap.tsx
@@ -1,8 +1,23 @@
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, ReactNode } from "react";
 import { Runtime, Inspector } from "@observablehq/runtime";
 import notebook from "c857fa5c110524ee";
 
-export function ZuzaluHypercertTreemap() {
+export interface ZuzaluHypercertTreemapProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+const defaultChildren = (
+  <p>
+    Credit:
+    <a href="https://observablehq.com/d/c857fa5c110524ee">
+      Zuzualu hypercerts by category by hypercerts
+    </a>
+  </p>
+);
+
+export function ZuzaluHypercertTreemap(props: ZuzaluHypercertTreemapProps) {
+  const { className, children } = props;
   const chartRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const runtime = new Runtime();
@@ -13,9 +28,9 @@ export function ZuzaluHypercertTreemap() {
   }, []);
 
   return (
-    <>
+    <div className={className}>
       <div ref={chartRef} />
-      <p>Credit: Zuzualu hypercerts by category by hypercerts,</p>
-    </>
+      {children ?? defaultChildren}
+    </div>
   );
 }

--- a/frontend/plasmic-init.ts
+++ b/frontend/plasmic-init.ts
@@ -551,6 +551,8 @@ PLASMIC.registerComponent(BurnFractionButton, {
 PLASMIC.registerComponent(ZuzaluHypercertTreemap, {
   name: "ZuzaluHypercertTreemap",
   description: "Zuzalu Hypercert Treemap from observerablehq",
-  props: {},
+  props: {
+    children: "slot",
+  },
   importPath: "./components/zuzalu-hypercert-treemap",
 });


### PR DESCRIPTION
Had noticed I had a silly trailing comma in the included caption for the treemap. This makes it so you can embed your own children in the component but also that it can properly be formatted by plasmic. 