### PR TITLE
Generic Treemap

### DIFF
--- a/frontend/components/generic-hypercert-treemap.tsx
+++ b/frontend/components/generic-hypercert-treemap.tsx
@@ -13,7 +13,7 @@ const defaultChildren = (
   <p>
     Credit:
     <a href="https://observablehq.com/d/c857fa5c110524ee">
-      Zuzualu hypercerts by category by hypercerts
+      Original notebook: hypercerts by category by hypercerts
     </a>
   </p>
 );

--- a/frontend/components/generic-hypercert-treemap.tsx
+++ b/frontend/components/generic-hypercert-treemap.tsx
@@ -1,0 +1,47 @@
+import React, { useRef, useEffect, ReactNode } from "react";
+import { Runtime, Inspector } from "@observablehq/runtime";
+import notebook from "@hypercerts-org/observabletreemap";
+
+export interface GenericHypercertTreemapProps {
+  className?: string;
+  children?: ReactNode;
+  backgroundImageUrl?: string;
+  data: object;
+}
+
+const defaultChildren = (
+  <p>
+    Credit:
+    <a href="https://observablehq.com/d/c857fa5c110524ee">
+      Zuzualu hypercerts by category by hypercerts
+    </a>
+  </p>
+);
+
+export function GenericHypercertTreemap(props: GenericHypercertTreemapProps) {
+  const { className, children, data, backgroundImageUrl } = props;
+  const chartRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const runtime = new Runtime();
+    const main = runtime.module(notebook, (name) => {
+      if (name === "chart") {
+        return new Inspector(chartRef.current);
+      }
+    });
+    main.redefine("data", data);
+
+    // Keeping this here for now because we'd like to get background images
+    //working if we can fix the rendering. The value passed into observable
+    //needs to be an HTMLImageElement. So the commented code doesn't exactly
+    //work yet.
+    //main.redefine("zuzaluLogo400x600", backgroundImageUrl);
+    return () => runtime.dispose();
+  }, []);
+
+  return (
+    <div className={className}>
+      <div ref={chartRef} />
+      {children ?? defaultChildren}
+    </div>
+  );
+}

--- a/frontend/components/generic-hypercert-treemap.tsx
+++ b/frontend/components/generic-hypercert-treemap.tsx
@@ -31,9 +31,9 @@ export function GenericHypercertTreemap(props: GenericHypercertTreemapProps) {
     main.redefine("data", data);
 
     // Keeping this here for now because we'd like to get background images
-    //working if we can fix the rendering. The value passed into observable
-    //needs to be an HTMLImageElement. So the commented code doesn't exactly
-    //work yet.
+    // working if we can fix the rendering. The value passed into observable
+    // needs to be an HTMLImageElement. So the commented code doesn't exactly
+    // work yet.
     //main.redefine("zuzaluLogo400x600", backgroundImageUrl);
     return () => runtime.dispose();
   }, []);

--- a/frontend/components/zuzalu-hypercert-treemap.compat.d.ts
+++ b/frontend/components/zuzalu-hypercert-treemap.compat.d.ts
@@ -4,8 +4,15 @@ type notebook = unknown;
 
 declare module "@observablehq/runtime" {
   declare class Runtime {
-    module(notebook: notebook, fn: (name: string) => Inspector | undefined);
+    module(
+      notebook: notebook,
+      fn: (name: string) => Inspector | undefined,
+    ): RuntimeModule;
     dispose();
+  }
+
+  declare class RuntimeModule {
+    redefine(target: string, value: any);
   }
   declare class Inspector {
     constructor(chartRef: any);

--- a/frontend/plasmic-init.ts
+++ b/frontend/plasmic-init.ts
@@ -20,6 +20,7 @@ import { SupabaseQuery } from "./components/supabase-query";
 import { SupabaseToChart } from "./components/supabase-to-chart";
 import { Tooltip, Accordion, Markdown } from "./components/widgets";
 import { ZuzaluHypercertTreemap } from "./components/zuzalu-hypercert-treemap";
+import { GenericHypercertTreemap } from "./components/generic-hypercert-treemap";
 import { PLASMIC_PROJECT_ID, PLASMIC_PROJECT_API_TOKEN } from "./lib/config";
 import CircularProgress from "@mui/material/CircularProgress";
 import { initPlasmicLoader } from "@plasmicapp/loader-nextjs";
@@ -555,4 +556,15 @@ PLASMIC.registerComponent(ZuzaluHypercertTreemap, {
     children: "slot",
   },
   importPath: "./components/zuzalu-hypercert-treemap",
+});
+
+PLASMIC.registerComponent(GenericHypercertTreemap, {
+  name: "GenericHypercertTreemap",
+  description: "Generic Hypercert Treemap from observerablehq",
+  props: {
+    children: "slot",
+    backgroundImageUrl: "imageUrl",
+    data: "object",
+  },
+  importPath: "./components/generic-hypercert-treemap",
 });


### PR DESCRIPTION
Resolves #884 

Adds a new GenericHypercertTreemap. At this time, it doesn't handle background images. We need to fix #883 first. 
