### PR TITLE
Fix builds after GenericHypercertsTreemap merge

### DIFF
--- a/frontend/components/generic-hypercert-treemap.tsx
+++ b/frontend/components/generic-hypercert-treemap.tsx
@@ -5,7 +5,7 @@ import notebook from "@hypercerts-org/observabletreemap";
 export interface GenericHypercertTreemapProps {
   className?: string;
   children?: ReactNode;
-  backgroundImageUrl?: string;
+  //backgroundImageUrl?: string;
   data: object;
 }
 
@@ -19,7 +19,7 @@ const defaultChildren = (
 );
 
 export function GenericHypercertTreemap(props: GenericHypercertTreemapProps) {
-  const { className, children, data, backgroundImageUrl } = props;
+  const { className, children, data } = props;
   const chartRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const runtime = new Runtime();
@@ -30,6 +30,7 @@ export function GenericHypercertTreemap(props: GenericHypercertTreemapProps) {
     });
     main.redefine("data", data);
 
+    // TODO: Fix backgroundImages. Leaving this inline for context later.
     // Keeping this here for now because we'd like to get background images
     // working if we can fix the rendering. The value passed into observable
     // needs to be an HTMLImageElement. So the commented code doesn't exactly

--- a/frontend/plasmic-init.ts
+++ b/frontend/plasmic-init.ts
@@ -563,7 +563,6 @@ PLASMIC.registerComponent(GenericHypercertTreemap, {
   description: "Generic Hypercert Treemap from observerablehq",
   props: {
     children: "slot",
-    backgroundImageUrl: "imageUrl",
     data: "object",
   },
   importPath: "./components/generic-hypercert-treemap",


### PR DESCRIPTION
My bad. Leaving some commented code in for a future self. 