### PR TITLE
Improve generic hypercerts treemap ux

### DIFF
--- a/frontend/components/generic-hypercert-treemap.tsx
+++ b/frontend/components/generic-hypercert-treemap.tsx
@@ -1,22 +1,25 @@
 import React, { useRef, useEffect, ReactNode } from "react";
 import { Runtime, Inspector } from "@observablehq/runtime";
 import notebook from "@hypercerts-org/observabletreemap";
+import { PlasmicElement } from "@plasmicapp/host";
 
 export interface GenericHypercertTreemapProps {
   className?: string;
-  children?: ReactNode;
+  children: ReactNode;
   //backgroundImageUrl?: string;
   data: object;
 }
 
-const defaultChildren = (
-  <p>
-    Credit:
-    <a href="https://observablehq.com/d/c857fa5c110524ee">
-      Original notebook: hypercerts by category by hypercerts
-    </a>
-  </p>
-);
+const defaultChildren: PlasmicElement[] = [
+  {
+    type: "text",
+    value: "Credit: Original notebook - hypercerts by category by hypercerts",
+    tag: "a",
+    attrs: {
+      href: "https://observablehq.com/d/c857fa5c110524ee",
+    },
+  },
+];
 
 export function GenericHypercertTreemap(props: GenericHypercertTreemapProps) {
   const { className, children, data } = props;
@@ -42,7 +45,9 @@ export function GenericHypercertTreemap(props: GenericHypercertTreemapProps) {
   return (
     <div className={className}>
       <div ref={chartRef} />
-      {children ?? defaultChildren}
+      {children}
     </div>
   );
 }
+
+GenericHypercertTreemap.defaultChildren = defaultChildren;

--- a/frontend/plasmic-init.ts
+++ b/frontend/plasmic-init.ts
@@ -562,8 +562,27 @@ PLASMIC.registerComponent(GenericHypercertTreemap, {
   name: "GenericHypercertTreemap",
   description: "Generic Hypercert Treemap from observerablehq",
   props: {
-    children: "slot",
-    data: "object",
+    children: {
+      type: "slot",
+      defaultValue: GenericHypercertTreemap.defaultChildren,
+    },
+    data: {
+      type: "object",
+      defaultValue: {
+        name: "EXAMPLE",
+        children: [
+          {
+            name: "Example",
+            children: [
+              {
+                name: "Invites",
+                value: 100,
+              },
+            ],
+          },
+        ],
+      },
+    },
   },
   importPath: "./components/generic-hypercert-treemap",
 });


### PR DESCRIPTION
This makes it so the component doesn't look broken when it is first dragged into the studio. 