### PR TITLE
Direct Hypercert fraction sale

### DIFF
--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -21,11 +21,6 @@ env:
 on:
   # A push occurs to one of the matched branches.
   push:
-  pull_request:
-    branches:
-      - main
-      - develop
-      - develop-contracts
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -8,7 +8,7 @@
     "no-console": "off",
     "no-empty-blocks": "off",
     "not-rely-on-time": "off",
-    "private-vars-leading-underscore": "warn",
+    "private-vars-leading-underscore": ["off", { "strict": false }],
     "reason-string": ["warn", { "maxLength": 64 }],
     "one-contract-per-file": "off"
   }

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -9,3 +9,4 @@ prb-test/=lib/prb-test/src/
 @looksrare/=node_modules/@looksrare/
 hardhat/=node_modules/hardhat/
 solmate/=node_modules/solmate/
+@openzeppelin/=node_modules/@openzeppelin/

--- a/contracts/src/marketplace/LooksRareProtocol.sol
+++ b/contracts/src/marketplace/LooksRareProtocol.sol
@@ -79,7 +79,7 @@ import {QuoteType} from "./enums/QuoteType.sol";
  *                                             ~~~      ~~~
  *                                              ~~~~  ~~~~
  *                                                ~~~~~~
- * @author LooksRare protocol team (👀,💎)
+ * @author LooksRare protocol team (👀,💎); bitbeckers
  */
 contract LooksRareProtocol is
     ILooksRareProtocol,

--- a/contracts/src/marketplace/TransferManager.sol
+++ b/contracts/src/marketplace/TransferManager.sol
@@ -259,6 +259,17 @@ contract TransferManager is ITransferManager, LowLevelERC721Transfer, LowLevelER
                     }
                 }
                 _executeERC1155SafeBatchTransferFrom(items[i].collection, from, to, itemIds, amounts);
+            } else if (collectionType == CollectionType.Hypercert) {
+                for (uint256 j; j < itemIdsLengthForSingleCollection;) {
+                    if (amounts[j] == 0) {
+                        revert AmountInvalid();
+                    }
+
+                    unchecked {
+                        ++j;
+                    }
+                }
+                _executeERC1155SafeBatchTransferFrom(items[i].collection, from, to, itemIds, amounts);
             }
 
             unchecked {

--- a/contracts/src/marketplace/TransferSelectorNFT.sol
+++ b/contracts/src/marketplace/TransferSelectorNFT.sol
@@ -59,7 +59,7 @@ contract TransferSelectorNFT is ExecutionManager, PackableReentrancyGuard {
         } else if (collectionType == CollectionType.ERC1155) {
             transferManager.transferItemsERC1155(collection, sender, recipient, itemIds, amounts);
         } else if (collectionType == CollectionType.Hypercert) {
-            transferManager.transferItemsERC1155(collection, sender, recipient, itemIds, amounts);
+            transferManager.transferItemsHypercert(collection, sender, recipient, itemIds, amounts);
         } else if (collectionType == CollectionType.Hyperboard) {
             revert UnsupportedCollectionType();
         }

--- a/contracts/src/marketplace/interfaces/ITransferManager.sol
+++ b/contracts/src/marketplace/interfaces/ITransferManager.sol
@@ -15,7 +15,7 @@ interface ITransferManager {
     /**
      * @notice This struct is only used for transferBatchItemsAcrossCollections.
      * @param collection Collection address
-     * @param collectionType 0 for ERC721, 1 for ERC1155
+     * @param collectionType 0 for ERC721, 1 for ERC1155, 2 for Hypercert, 3 for Hyperboard
      * @param itemIds Array of item ids to transfer
      * @param amounts Array of amounts to transfer
      */

--- a/contracts/src/protocol/AllowlistMinter.sol
+++ b/contracts/src/protocol/AllowlistMinter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity ^0.8.16;
 
 import {MerkleProofUpgradeable} from "oz-upgradeable/utils/cryptography/MerkleProofUpgradeable.sol";
 import {IAllowlist} from "./interfaces/IAllowlist.sol";

--- a/contracts/src/protocol/HypercertMinter.sol
+++ b/contracts/src/protocol/HypercertMinter.sol
@@ -8,8 +8,6 @@ import {PausableUpgradeable} from "oz-upgradeable/security/PausableUpgradeable.s
 
 import {Errors} from "./libs/Errors.sol";
 
-import "forge-std/console.sol";
-
 /// @title Contract for managing hypercert claims and whitelists
 /// @author bitbeckers
 /// @notice Implementation of the HypercertTokenInterface using { SemiFungible1155 } as underlying token.
@@ -230,15 +228,11 @@ contract HypercertMinter is IHypercertToken, SemiFungible1155, AllowlistMinter, 
         // Transfer case, where to and from are non-zero
         uint256 len = ids.length;
         for (uint256 i; i < len;) {
-            console.log("Validating permissions");
             uint256 typeID = getBaseType(ids[i]);
             TransferRestrictions policy = typeRestrictions[typeID];
             if (policy == TransferRestrictions.DisallowAll) {
                 revert Errors.TransfersNotAllowed();
             } else if (policy == TransferRestrictions.FromCreatorOnly && from != creators[typeID]) {
-                console.log("Not allowed: from != creator");
-                console.log("from: %s != creator", from, creators[typeID]);
-
                 revert Errors.TransfersNotAllowed();
             }
             unchecked {

--- a/contracts/src/protocol/HypercertMinter.sol
+++ b/contracts/src/protocol/HypercertMinter.sol
@@ -8,6 +8,8 @@ import {PausableUpgradeable} from "oz-upgradeable/security/PausableUpgradeable.s
 
 import {Errors} from "./libs/Errors.sol";
 
+import "forge-std/console.sol";
+
 /// @title Contract for managing hypercert claims and whitelists
 /// @author bitbeckers
 /// @notice Implementation of the HypercertTokenInterface using { SemiFungible1155 } as underlying token.
@@ -228,11 +230,15 @@ contract HypercertMinter is IHypercertToken, SemiFungible1155, AllowlistMinter, 
         // Transfer case, where to and from are non-zero
         uint256 len = ids.length;
         for (uint256 i; i < len;) {
+            console.log("Validating permissions");
             uint256 typeID = getBaseType(ids[i]);
             TransferRestrictions policy = typeRestrictions[typeID];
             if (policy == TransferRestrictions.DisallowAll) {
                 revert Errors.TransfersNotAllowed();
             } else if (policy == TransferRestrictions.FromCreatorOnly && from != creators[typeID]) {
+                console.log("Not allowed: from != creator");
+                console.log("from: %s != creator", from, creators[typeID]);
+
                 revert Errors.TransfersNotAllowed();
             }
             unchecked {

--- a/contracts/src/protocol/HypercertMinter.sol
+++ b/contracts/src/protocol/HypercertMinter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity ^0.8.16;
 
 import {IHypercertToken} from "./interfaces/IHypercertToken.sol";
 import {SemiFungible1155} from "./SemiFungible1155.sol";

--- a/contracts/src/protocol/SemiFungible1155.sol
+++ b/contracts/src/protocol/SemiFungible1155.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Used components of Enjin example implementation for mixed fungibility
 // https://github.com/enjin/erc-1155/blob/master/contracts/ERC1155MixedFungibleMintable.sol
-pragma solidity 0.8.16;
+pragma solidity ^0.8.16;
 
 import {ERC1155Upgradeable} from "oz-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
 import {ERC1155BurnableUpgradeable} from "oz-upgradeable/token/ERC1155/extensions/ERC1155BurnableUpgradeable.sol";

--- a/contracts/src/protocol/interfaces/IAllowlist.sol
+++ b/contracts/src/protocol/interfaces/IAllowlist.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity ^0.8.16;
 
 /// @title Interface for allowlist
 /// @author bitbeckers

--- a/contracts/src/protocol/interfaces/IHypercertToken.sol
+++ b/contracts/src/protocol/interfaces/IHypercertToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.16;
+pragma solidity ^0.8.16;
 
 /// @title Interface for hypercert token interactions
 /// @author bitbeckers

--- a/contracts/test/foundry/marketplace/ProtocolBase.t.sol
+++ b/contracts/test/foundry/marketplace/ProtocolBase.t.sol
@@ -11,6 +11,8 @@ import {OrderStructs} from "@hypercerts/marketplace/libraries/OrderStructs.sol";
 import {LooksRareProtocol, ILooksRareProtocol} from "@hypercerts/marketplace/LooksRareProtocol.sol";
 import {TransferManager} from "@hypercerts/marketplace/TransferManager.sol";
 import {ProtocolFeeRecipient} from "@hypercerts/marketplace/ProtocolFeeRecipient.sol";
+import {HypercertMinter} from "@hypercerts/protocol/HypercertMinter.sol";
+import {IHypercertToken} from "@hypercerts/protocol/interfaces/IHypercertToken.sol";
 
 // Other contracts
 import {OrderValidatorV2A} from "@hypercerts/marketplace/helpers/OrderValidatorV2A.sol";
@@ -21,6 +23,7 @@ import {MockERC721} from "../../mock/MockERC721.sol";
 import {MockERC721WithRoyalties} from "../../mock/MockERC721WithRoyalties.sol";
 import {MockERC1155} from "../../mock/MockERC1155.sol";
 import {MockRoyaltyFeeRegistry} from "../../mock/MockRoyaltyFeeRegistry.sol";
+import {MockHypercertMinterUUPS} from "../../mock/MockHypercertMinterUUPS.sol";
 
 // Utils
 import {MockOrderGenerator} from "./utils/MockOrderGenerator.sol";
@@ -32,6 +35,11 @@ contract ProtocolBase is MockOrderGenerator, ILooksRareProtocol {
     MockERC721WithRoyalties public mockERC721WithRoyalties;
     MockERC721 public mockERC721;
     MockERC1155 public mockERC1155;
+    MockHypercertMinterUUPS public mockHypercertMinterUUPS;
+    HypercertMinter public mockHypercertMinter;
+
+    IHypercertToken.TransferRestrictions public constant FROM_CREATOR_ONLY =
+        IHypercertToken.TransferRestrictions.FromCreatorOnly;
 
     ProtocolFeeRecipient public protocolFeeRecipient;
     LooksRareProtocol public looksRareProtocol;
@@ -125,6 +133,8 @@ contract ProtocolBase is MockOrderGenerator, ILooksRareProtocol {
         mockERC721.setApprovalForAll(address(transferManager), true);
         mockERC1155.setApprovalForAll(address(transferManager), true);
         mockERC721WithRoyalties.setApprovalForAll(address(transferManager), true);
+        mockHypercertMinter.setApprovalForAll(address(transferManager), true);
+
         weth.approve(address(looksRareProtocol), type(uint256).max);
 
         // Grant approvals for transfer manager
@@ -153,6 +163,9 @@ contract ProtocolBase is MockOrderGenerator, ILooksRareProtocol {
         looksRareToken = new MockERC20();
         mockERC721 = new MockERC721();
         mockERC1155 = new MockERC1155();
+        mockHypercertMinterUUPS = new MockHypercertMinterUUPS();
+        mockHypercertMinterUUPS.setUp();
+        mockHypercertMinter = mockHypercertMinterUUPS.minter();
 
         transferManager = new TransferManager(_owner);
         royaltyFeeRegistry = new MockRoyaltyFeeRegistry(_owner, 9500);

--- a/contracts/test/foundry/marketplace/SignaturesERC1271WalletForHypercert.t.sol
+++ b/contracts/test/foundry/marketplace/SignaturesERC1271WalletForHypercert.t.sol
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+// Libraries and interfaces
+import {IReentrancyGuard} from "@looksrare/contracts-libs/contracts/interfaces/IReentrancyGuard.sol";
+import {OrderStructs} from "@hypercerts/marketplace/libraries/OrderStructs.sol";
+
+// Base test
+import {ProtocolBase} from "./ProtocolBase.t.sol";
+
+// Mocks and other utils
+import {ERC1271Wallet} from "./utils/ERC1271Wallet.sol";
+import {MaliciousERC1271Wallet} from "./utils/MaliciousERC1271Wallet.sol";
+import {MaliciousOnERC1155ReceivedERC1271Wallet} from "./utils/MaliciousOnERC1155ReceivedERC1271Wallet.sol";
+import {MaliciousOnERC1155ReceivedTheThirdTimeERC1271Wallet} from
+    "./utils/MaliciousOnERC1155ReceivedTheThirdTimeERC1271Wallet.sol";
+import {MaliciousIsValidSignatureERC1271Wallet} from "./utils/MaliciousIsValidSignatureERC1271Wallet.sol";
+
+// Errors
+import {SignatureERC1271Invalid} from "@looksrare/contracts-libs/contracts/errors/SignatureCheckerErrors.sol";
+import {
+    ERC1155SafeTransferFromFail,
+    ERC1155SafeBatchTransferFromFail
+} from "@looksrare/contracts-libs/contracts/errors/LowLevelErrors.sol";
+import {SIGNATURE_INVALID_EIP1271} from "@hypercerts/marketplace/constants/ValidationCodeConstants.sol";
+
+// Enums
+import {CollectionType} from "@hypercerts/marketplace/enums/CollectionType.sol";
+import {QuoteType} from "@hypercerts/marketplace/enums/QuoteType.sol";
+
+/**
+ * @dev ERC1271Wallet recovers a signature's signer using ECDSA. If it matches the mock wallet's
+ *      owner, it returns the magic value. Otherwise it returns an empty bytes4 value.
+ */
+contract SignaturesERC1271WalletForHypercertTest is ProtocolBase {
+    uint256 private constant price = 1 ether; // Fixed price of sale
+    uint256 private constant fractionId = (1 << 128) + 1;
+    bytes private constant _EMPTY_SIGNATURE = new bytes(0);
+
+    function setUp() public {
+        _setUp();
+        _setUpUser(takerUser);
+        _setupRegistryRoyalties(address(mockHypercertMinter), _standardRoyaltyFee);
+    }
+
+    function testTakerBid() public {
+        ERC1271Wallet wallet = new ERC1271Wallet(address(makerUser));
+        (OrderStructs.Maker memory makerAsk, OrderStructs.Taker memory takerBid) = _takerBidSetup(address(wallet));
+
+        bytes memory signature = _signMakerOrder(makerAsk, makerUserPK);
+
+        vm.startPrank(address(wallet));
+        mockHypercertMinter.setApprovalForAll(address(transferManager), true);
+        transferManager.grantApprovals(operators);
+        vm.stopPrank();
+
+        _assertValidMakerOrder(makerAsk, signature);
+
+        vm.prank(takerUser);
+        looksRareProtocol.executeTakerBid{value: price}(takerBid, makerAsk, signature, _EMPTY_MERKLE_TREE);
+
+        assertEq(mockHypercertMinter.balanceOf(takerUser, fractionId), 1);
+    }
+
+    function testTakerBidInvalidSignature() public {
+        ERC1271Wallet wallet = new ERC1271Wallet(address(makerUser));
+        (OrderStructs.Maker memory makerAsk, OrderStructs.Taker memory takerBid) = _takerBidSetup(address(wallet));
+
+        // Signed by a different private key
+        bytes memory signature = _signMakerOrder(makerAsk, takerUserPK);
+
+        vm.startPrank(address(wallet));
+        mockHypercertMinter.setApprovalForAll(address(transferManager), true);
+        transferManager.grantApprovals(operators);
+        vm.stopPrank();
+
+        _assertMakerOrderReturnValidationCode(makerAsk, signature, SIGNATURE_INVALID_EIP1271);
+
+        vm.expectRevert(SignatureERC1271Invalid.selector);
+        vm.prank(takerUser);
+        looksRareProtocol.executeTakerBid{value: price}(takerBid, makerAsk, signature, _EMPTY_MERKLE_TREE);
+    }
+
+    function testTakerBidIsInvalidSignatureReentrancy() public {
+        MaliciousIsValidSignatureERC1271Wallet maliciousERC1271Wallet = new MaliciousIsValidSignatureERC1271Wallet(
+            address(looksRareProtocol)
+        );
+        _setUpUser(address(maliciousERC1271Wallet));
+        maliciousERC1271Wallet.setFunctionToReenter(MaliciousERC1271Wallet.FunctionToReenter.ExecuteTakerBid);
+
+        (OrderStructs.Maker memory makerAsk, OrderStructs.Taker memory takerBid) =
+            _takerBidSetup(address(maliciousERC1271Wallet));
+
+        vm.expectRevert(IReentrancyGuard.ReentrancyFail.selector);
+        vm.prank(takerUser);
+        looksRareProtocol.executeTakerBid{value: price}(takerBid, makerAsk, _EMPTY_SIGNATURE, _EMPTY_MERKLE_TREE);
+    }
+
+    function testTakerAsk() public {
+        ERC1271Wallet wallet = new ERC1271Wallet(address(makerUser));
+        (OrderStructs.Taker memory takerAsk, OrderStructs.Maker memory makerBid) = _takerAskSetup(address(wallet));
+
+        bytes memory signature = _signMakerOrder(makerBid, makerUserPK);
+
+        // Wallet needs to hold WETH and have given WETH approval
+        deal(address(weth), address(wallet), price);
+        vm.prank(address(wallet));
+        weth.approve(address(looksRareProtocol), price);
+
+        _assertValidMakerOrder(makerBid, signature);
+
+        vm.prank(takerUser);
+        looksRareProtocol.executeTakerAsk(takerAsk, makerBid, signature, _EMPTY_MERKLE_TREE);
+
+        assertEq(mockHypercertMinter.balanceOf(address(wallet), fractionId), 1);
+    }
+
+    function testTakerAskInvalidSignature() public {
+        ERC1271Wallet wallet = new ERC1271Wallet(address(makerUser));
+        (OrderStructs.Taker memory takerAsk, OrderStructs.Maker memory makerBid) = _takerAskSetup(address(wallet));
+
+        // Signed by a different private key
+        bytes memory signature = _signMakerOrder(makerBid, takerUserPK);
+
+        // Wallet needs to hold WETH and have given WETH approval
+        deal(address(weth), address(wallet), price);
+        vm.prank(address(wallet));
+        weth.approve(address(looksRareProtocol), price);
+
+        _assertMakerOrderReturnValidationCode(makerBid, signature, SIGNATURE_INVALID_EIP1271);
+
+        vm.expectRevert(SignatureERC1271Invalid.selector);
+        vm.prank(takerUser);
+        looksRareProtocol.executeTakerAsk(takerAsk, makerBid, signature, _EMPTY_MERKLE_TREE);
+    }
+
+    function testTakerAskIsValidSignatureReentrancy() public {
+        MaliciousIsValidSignatureERC1271Wallet maliciousERC1271Wallet = new MaliciousIsValidSignatureERC1271Wallet(
+            address(looksRareProtocol)
+        );
+        _setUpUser(address(maliciousERC1271Wallet));
+        maliciousERC1271Wallet.setFunctionToReenter(MaliciousERC1271Wallet.FunctionToReenter.ExecuteTakerAsk);
+
+        (OrderStructs.Taker memory takerAsk, OrderStructs.Maker memory makerBid) =
+            _takerAskSetup(address(maliciousERC1271Wallet));
+
+        vm.expectRevert(IReentrancyGuard.ReentrancyFail.selector);
+        vm.prank(takerUser);
+        looksRareProtocol.executeTakerAsk(takerAsk, makerBid, _EMPTY_SIGNATURE, _EMPTY_MERKLE_TREE);
+    }
+
+    function testTakerAskOnERC1155ReceivedReentrancy() public {
+        MaliciousOnERC1155ReceivedERC1271Wallet maliciousERC1271Wallet = new MaliciousOnERC1155ReceivedERC1271Wallet(
+            address(looksRareProtocol)
+        );
+        _setUpUser(address(maliciousERC1271Wallet));
+
+        (OrderStructs.Taker memory takerAsk, OrderStructs.Maker memory makerBid) =
+            _takerAskSetup(address(maliciousERC1271Wallet));
+
+        maliciousERC1271Wallet.setFunctionToReenter(MaliciousERC1271Wallet.FunctionToReenter.ExecuteTakerAsk);
+
+        vm.expectRevert(ERC1155SafeTransferFromFail.selector);
+        vm.prank(takerUser);
+        looksRareProtocol.executeTakerAsk(takerAsk, makerBid, _EMPTY_SIGNATURE, _EMPTY_MERKLE_TREE);
+    }
+
+    function testBatchTakerAsk() public {
+        ERC1271Wallet wallet = new ERC1271Wallet(makerUser);
+        (OrderStructs.Taker memory takerAsk, OrderStructs.Maker memory makerBid) = _batchTakerAskSetup(address(wallet));
+
+        bytes memory signature = _signMakerOrder(makerBid, makerUserPK);
+
+        // Wallet needs to hold WETH and have given WETH approval
+        deal(address(weth), address(wallet), price);
+        vm.prank(address(wallet));
+        weth.approve(address(looksRareProtocol), price);
+
+        vm.prank(takerUser);
+        looksRareProtocol.executeTakerAsk(takerAsk, makerBid, signature, _EMPTY_MERKLE_TREE);
+
+        for (uint256 i; i < 10; i++) {
+            assertEq(mockHypercertMinter.balanceOf(address(wallet), (((1 + i) << 128) + 1)), 1);
+        }
+    }
+
+    function testBatchTakerAskOnERC1155BatchReceivedReentrancy() public {
+        MaliciousOnERC1155ReceivedERC1271Wallet maliciousERC1271Wallet = new MaliciousOnERC1155ReceivedERC1271Wallet(
+            address(looksRareProtocol)
+        );
+        _setUpUser(address(maliciousERC1271Wallet));
+
+        (OrderStructs.Taker memory takerAsk, OrderStructs.Maker memory makerBid) =
+            _batchTakerAskSetup(address(maliciousERC1271Wallet));
+
+        bytes memory signature = _signMakerOrder(makerBid, makerUserPK);
+
+        // Wallet needs to hold WETH and have given WETH approval
+        deal(address(weth), address(maliciousERC1271Wallet), price);
+        vm.prank(address(maliciousERC1271Wallet));
+        weth.approve(address(looksRareProtocol), price);
+
+        maliciousERC1271Wallet.setFunctionToReenter(MaliciousERC1271Wallet.FunctionToReenter.ExecuteTakerAsk);
+
+        vm.expectRevert(ERC1155SafeBatchTransferFromFail.selector);
+        vm.prank(takerUser);
+        looksRareProtocol.executeTakerAsk(takerAsk, makerBid, signature, _EMPTY_MERKLE_TREE);
+    }
+
+    uint256 private constant numberOfPurchases = 3;
+
+    function testExecuteMultipleTakerBids() public {
+        ERC1271Wallet wallet = new ERC1271Wallet(address(makerUser));
+
+        (
+            OrderStructs.Maker[] memory makerAsks,
+            OrderStructs.Taker[] memory takerBids,
+            OrderStructs.MerkleTree[] memory merkleTrees,
+            bytes[] memory signatures
+        ) = _multipleTakerBidsSetup(address(wallet));
+
+        vm.startPrank(address(wallet));
+        mockHypercertMinter.setApprovalForAll(address(transferManager), true);
+        transferManager.grantApprovals(operators);
+        vm.stopPrank();
+
+        vm.prank(takerUser);
+        looksRareProtocol.executeMultipleTakerBids{value: price * numberOfPurchases}(
+            takerBids, makerAsks, signatures, merkleTrees, false
+        );
+
+        for (uint256 i; i < numberOfPurchases; i++) {
+            assertEq(mockHypercertMinter.balanceOf(takerUser, (((1 + i) << 128) + 1)), 1);
+        }
+    }
+
+    function testExecuteMultipleTakerBidsInvalidSignatures() public {
+        ERC1271Wallet wallet = new ERC1271Wallet(address(makerUser));
+
+        (
+            OrderStructs.Maker[] memory makerAsks,
+            OrderStructs.Taker[] memory takerBids,
+            OrderStructs.MerkleTree[] memory merkleTrees,
+            bytes[] memory signatures
+        ) = _multipleTakerBidsSetup(address(wallet));
+
+        // Signed by a different private key
+        for (uint256 i; i < signatures.length; i++) {
+            signatures[i] = _signMakerOrder(makerAsks[i], takerUserPK);
+        }
+
+        vm.startPrank(address(wallet));
+        mockHypercertMinter.setApprovalForAll(address(transferManager), true);
+        transferManager.grantApprovals(operators);
+        vm.stopPrank();
+
+        vm.expectRevert(SignatureERC1271Invalid.selector);
+        vm.prank(takerUser);
+        looksRareProtocol.executeMultipleTakerBids{value: price * numberOfPurchases}(
+            takerBids, makerAsks, signatures, merkleTrees, false
+        );
+    }
+
+    function testExecuteMultipleTakerBidsIsValidSignatureReentrancy() public {
+        MaliciousIsValidSignatureERC1271Wallet maliciousERC1271Wallet = new MaliciousIsValidSignatureERC1271Wallet(
+            address(looksRareProtocol)
+        );
+        _setUpUser(address(maliciousERC1271Wallet));
+        maliciousERC1271Wallet.setFunctionToReenter(MaliciousERC1271Wallet.FunctionToReenter.ExecuteMultipleTakerBids);
+
+        (
+            OrderStructs.Maker[] memory makerAsks,
+            OrderStructs.Taker[] memory takerBids,
+            OrderStructs.MerkleTree[] memory merkleTrees,
+            bytes[] memory signatures
+        ) = _multipleTakerBidsSetup(address(maliciousERC1271Wallet));
+
+        vm.expectRevert(IReentrancyGuard.ReentrancyFail.selector);
+        vm.prank(takerUser);
+        looksRareProtocol.executeMultipleTakerBids{value: price * numberOfPurchases}(
+            takerBids, makerAsks, signatures, merkleTrees, false
+        );
+
+        for (uint256 i; i < numberOfPurchases - 1; i++) {
+            assertEq(mockHypercertMinter.balanceOf(takerUser, i), 0);
+        }
+    }
+
+    function testExecuteMultipleTakerBidsOnERC1155ReceivedReentrancyOnlyInTheLastCall() public {
+        MaliciousOnERC1155ReceivedTheThirdTimeERC1271Wallet maliciousERC1271Wallet =
+        new MaliciousOnERC1155ReceivedTheThirdTimeERC1271Wallet(
+                takerUser
+            );
+        _setUpUser(makerUser);
+        maliciousERC1271Wallet.setFunctionToReenter(MaliciousERC1271Wallet.FunctionToReenter.ExecuteMultipleTakerBids);
+
+        (
+            OrderStructs.Maker[] memory makerAsks,
+            OrderStructs.Taker[] memory takerBids,
+            OrderStructs.MerkleTree[] memory merkleTrees,
+            bytes[] memory signatures
+        ) = _multipleTakerBidsSetup(makerUser);
+
+        // Set the NFT recipient as the ERC1271 wallet to trigger onERC1155Received
+        for (uint256 i; i < numberOfPurchases; i++) {
+            takerBids[i].recipient = address(maliciousERC1271Wallet);
+        }
+
+        vm.prank(takerUser);
+        looksRareProtocol.executeMultipleTakerBids{value: price * numberOfPurchases}(
+            takerBids, makerAsks, signatures, merkleTrees, false
+        );
+
+        // First 2 purchases should go through, but the last one fails silently
+        for (uint256 i; i < numberOfPurchases - 1; i++) {
+            assertEq(mockHypercertMinter.balanceOf(address(maliciousERC1271Wallet), (((1 + i) << 128) + 1)), 1);
+        }
+        assertEq(mockHypercertMinter.balanceOf(address(maliciousERC1271Wallet), numberOfPurchases - 1), 0);
+    }
+
+    function _takerBidSetup(address signer)
+        private
+        returns (OrderStructs.Maker memory makerAsk, OrderStructs.Taker memory takerBid)
+    {
+        // Mint asset
+        vm.prank(signer);
+        mockHypercertMinter.mintClaim(signer, 10_000, "http://example.com/takerBid", FROM_CREATOR_ONLY);
+
+        makerAsk = _createSingleItemMakerOrder({
+            quoteType: QuoteType.Ask,
+            globalNonce: 0,
+            subsetNonce: 0,
+            strategyId: STANDARD_SALE_FOR_FIXED_PRICE_STRATEGY,
+            collectionType: CollectionType.Hypercert,
+            orderNonce: 0,
+            collection: address(mockHypercertMinter),
+            currency: ETH,
+            signer: signer,
+            price: price,
+            itemId: fractionId
+        });
+
+        // Prepare the taker bid
+        takerBid = _genericTakerOrder();
+    }
+
+    function _takerAskSetup(address signer)
+        private
+        returns (OrderStructs.Taker memory takerAsk, OrderStructs.Maker memory makerBid)
+    {
+        makerBid = _createSingleItemMakerOrder({
+            quoteType: QuoteType.Bid,
+            globalNonce: 0,
+            subsetNonce: 0,
+            strategyId: STANDARD_SALE_FOR_FIXED_PRICE_STRATEGY,
+            collectionType: CollectionType.Hypercert,
+            orderNonce: 0,
+            collection: address(mockHypercertMinter),
+            currency: address(weth),
+            signer: signer,
+            price: price,
+            itemId: fractionId
+        });
+
+        // Mint asset
+        vm.prank(takerUser);
+        mockHypercertMinter.mintClaim(takerUser, 10_000, "http://example.com/takerBid", FROM_CREATOR_ONLY);
+
+        // Prepare the taker ask
+        takerAsk = _genericTakerOrder();
+    }
+
+    function _batchTakerAskSetup(address signer)
+        private
+        returns (OrderStructs.Taker memory takerAsk, OrderStructs.Maker memory makerBid)
+    {
+        uint256[] memory itemIds = new uint256[](10);
+        uint256[] memory amounts = new uint256[](10);
+
+        vm.startPrank(takerUser);
+        for (uint256 i; i < 10; i++) {
+            uint256 claimID = (1 + i) << 128;
+            itemIds[i] = claimID + 1;
+            amounts[i] = 1;
+
+            // Mint asset
+            mockHypercertMinter.mintClaim(takerUser, 10_000, "http://example.com/takerBid", FROM_CREATOR_ONLY);
+        }
+        vm.stopPrank();
+
+        // Prepare the first order
+        makerBid = _createMultiItemMakerOrder({
+            quoteType: QuoteType.Bid,
+            globalNonce: 0,
+            subsetNonce: 0,
+            strategyId: STANDARD_SALE_FOR_FIXED_PRICE_STRATEGY,
+            collectionType: CollectionType.Hypercert,
+            orderNonce: 0,
+            collection: address(mockHypercertMinter),
+            currency: address(weth),
+            signer: signer,
+            price: price,
+            itemIds: itemIds,
+            amounts: amounts
+        });
+
+        // Prepare the taker ask
+        takerAsk = _genericTakerOrder();
+    }
+
+    function _multipleTakerBidsSetup(address signer)
+        private
+        returns (
+            OrderStructs.Maker[] memory makerAsks,
+            OrderStructs.Taker[] memory takerBids,
+            OrderStructs.MerkleTree[] memory merkleTrees,
+            bytes[] memory signatures
+        )
+    {
+        makerAsks = new OrderStructs.Maker[](numberOfPurchases);
+        takerBids = new OrderStructs.Taker[](numberOfPurchases);
+        signatures = new bytes[](numberOfPurchases);
+
+        vm.startPrank(signer);
+        for (uint256 i; i < numberOfPurchases; i++) {
+            // Mint asset
+            mockHypercertMinter.mintClaim(signer, 10_000, "http://example.com/takerBid", FROM_CREATOR_ONLY);
+
+            uint256 fractionID = ((1 + i) << 128) + 1;
+
+            makerAsks[i] = _createSingleItemMakerOrder({
+                quoteType: QuoteType.Ask,
+                globalNonce: 0,
+                subsetNonce: 0,
+                strategyId: STANDARD_SALE_FOR_FIXED_PRICE_STRATEGY,
+                collectionType: CollectionType.ERC1155,
+                orderNonce: i,
+                collection: address(mockHypercertMinter),
+                currency: ETH,
+                signer: signer,
+                price: price,
+                itemId: fractionID // 0, 1, etc.
+            });
+
+            signatures[i] = _signMakerOrder(makerAsks[i], makerUserPK);
+
+            takerBids[i] = _genericTakerOrder();
+        }
+        vm.stopPrank();
+
+        // Other execution parameters
+        merkleTrees = new OrderStructs.MerkleTree[](numberOfPurchases);
+    }
+}

--- a/contracts/test/foundry/marketplace/StrategyManager.t.sol
+++ b/contracts/test/foundry/marketplace/StrategyManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity ^0.8.17;
 
 // LooksRare unopinionated libraries
 import {IOwnableTwoSteps} from "@looksrare/contracts-libs/contracts/interfaces/IOwnableTwoSteps.sol";

--- a/contracts/test/foundry/marketplace/TransferManager.t.sol
+++ b/contracts/test/foundry/marketplace/TransferManager.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.16;
+pragma solidity ^0.8.17;
 
 // LooksRare unopinionated libraries
 import {IOwnableTwoSteps} from "@looksrare/contracts-libs/contracts/interfaces/IOwnableTwoSteps.sol";

--- a/contracts/test/foundry/marketplace/utils/MockOrderGenerator.sol
+++ b/contracts/test/foundry/marketplace/utils/MockOrderGenerator.sol
@@ -20,8 +20,16 @@ contract MockOrderGenerator is ProtocolHelpers {
         view
         returns (OrderStructs.Maker memory newMakerAsk, OrderStructs.Taker memory newTakerBid)
     {
-        CollectionType collectionType = _getCollectionType(collection);
+        return _createMockMakerAskAndTakerBid(collection, false);
+    }
 
+    function _createMockMakerAskAndTakerBid(address collection, bool hypercerts)
+        internal
+        view
+        returns (OrderStructs.Maker memory newMakerAsk, OrderStructs.Taker memory newTakerBid)
+    {
+        CollectionType collectionType = hypercerts ? CollectionType.Hypercert : _getCollectionType(collection);
+        uint256 itemId = hypercerts ? ((1 << 128) + 1) : 420;
         newMakerAsk = _createSingleItemMakerOrder({
             quoteType: QuoteType.Ask,
             globalNonce: 0,
@@ -33,7 +41,7 @@ contract MockOrderGenerator is ProtocolHelpers {
             currency: ETH,
             signer: makerUser,
             price: 1 ether,
-            itemId: 420
+            itemId: itemId
         });
 
         newTakerBid = OrderStructs.Taker(takerUser, abi.encode());
@@ -44,7 +52,15 @@ contract MockOrderGenerator is ProtocolHelpers {
         view
         returns (OrderStructs.Maker memory newMakerBid, OrderStructs.Taker memory newTakerAsk)
     {
-        CollectionType collectionType = _getCollectionType(collection);
+        return _createMockMakerBidAndTakerAsk(collection, currency, false);
+    }
+
+    function _createMockMakerBidAndTakerAsk(address collection, address currency, bool hypercerts)
+        internal
+        view
+        returns (OrderStructs.Maker memory newMakerBid, OrderStructs.Taker memory newTakerAsk)
+    {
+        CollectionType collectionType = hypercerts ? CollectionType.Hypercert : _getCollectionType(collection);
 
         newMakerBid = _createSingleItemMakerOrder({
             quoteType: QuoteType.Bid,
@@ -57,7 +73,7 @@ contract MockOrderGenerator is ProtocolHelpers {
             currency: currency,
             signer: makerUser,
             price: 1 ether,
-            itemId: 420
+            itemId: hypercerts ? (1 << 128) + 1 : 420
         });
 
         newTakerAsk = OrderStructs.Taker(takerUser, abi.encode());
@@ -68,7 +84,15 @@ contract MockOrderGenerator is ProtocolHelpers {
         view
         returns (OrderStructs.Maker memory newMakerAsk, OrderStructs.Taker memory newTakerBid)
     {
-        CollectionType collectionType = _getCollectionType(collection);
+        return _createMockMakerAskAndTakerBidWithBundle(collection, numberTokens, false);
+    }
+
+    function _createMockMakerAskAndTakerBidWithBundle(address collection, uint256 numberTokens, bool hypercerts)
+        internal
+        view
+        returns (OrderStructs.Maker memory newMakerAsk, OrderStructs.Taker memory newTakerBid)
+    {
+        CollectionType collectionType = hypercerts ? CollectionType.Hypercert : _getCollectionType(collection);
 
         (uint256[] memory itemIds, uint256[] memory amounts) = _setBundleItemIdsAndAmounts(collectionType, numberTokens);
 
@@ -95,7 +119,16 @@ contract MockOrderGenerator is ProtocolHelpers {
         view
         returns (OrderStructs.Maker memory newMakerBid, OrderStructs.Taker memory newTakerAsk)
     {
-        CollectionType collectionType = _getCollectionType(collection);
+        return _createMockMakerBidAndTakerAskWithBundle(collection, currency, numberTokens, false);
+    }
+
+    function _createMockMakerBidAndTakerAskWithBundle(
+        address collection,
+        address currency,
+        uint256 numberTokens,
+        bool hypercerts
+    ) internal view returns (OrderStructs.Maker memory newMakerBid, OrderStructs.Taker memory newTakerAsk) {
+        CollectionType collectionType = hypercerts ? CollectionType.Hypercert : _getCollectionType(collection);
 
         (uint256[] memory itemIds, uint256[] memory amounts) = _setBundleItemIdsAndAmounts(collectionType, numberTokens);
 
@@ -137,6 +170,9 @@ contract MockOrderGenerator is ProtocolHelpers {
         for (uint256 i; i < itemIds.length; i++) {
             itemIds[i] = i;
             if (collectionType != CollectionType.ERC1155) {
+                amounts[i] = 1;
+            } else if (collectionType == CollectionType.Hypercert) {
+                itemIds[i] = (1 << 128) + 1 + i;
                 amounts[i] = 1;
             } else {
                 amounts[i] = 1 + i;

--- a/contracts/test/mock/MockHypercertMinterUUPS.sol
+++ b/contracts/test/mock/MockHypercertMinterUUPS.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+import {HypercertMinter} from "@hypercerts/protocol/HypercertMinter.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract UUPSProxy is ERC1967Proxy {
+    constructor(address implementation, bytes memory data) ERC1967Proxy(implementation, data) {}
+}
+
+contract MockHypercertMinterUUPS {
+    HypercertMinter public instance;
+    UUPSProxy public proxy;
+    HypercertMinter public minter;
+
+    function setUp() public {
+        instance = new HypercertMinter();
+        proxy = new UUPSProxy(address(instance), "");
+        minter = HypercertMinter(address(proxy));
+    }
+}


### PR DESCRIPTION
* fix compiler linting warnings (for instance ^0.8.16 instead of 0.8.16)
* expand Transfer Manager tests with Hypercerts collection usecases
* add hypercertUUPS and hypercertMinter to ProtocolBase
* expand Signature tests for Hypercerts maker, taker, ask, bid, batch flows
* expand Standard Transactions tests with suite for Hypercerts

Implements:
#1109 
#1107 
#1111 