### PR TITLE
fix(lowercase): compare addresses lowercased

### DIFF
--- a/frontend/hooks/verifyFractionClaim.ts
+++ b/frontend/hooks/verifyFractionClaim.ts
@@ -44,7 +44,7 @@ export const useVerifyFractionClaim = () => {
 
       // Find the proof
       for (const [leaf, value] of tree.entries()) {
-        if (value[0] === address) {
+        if (value[0].toLowerCase() === address.toLowerCase()) {
           results.push({
             proof: tree.getProof(leaf),
             units: Number(value[1]),


### PR DESCRIPTION
When retrieving proofs from allowlists, addresses should be lowercased.