### PR TITLE
(fix): updated "edit this page" link in the docusaurus configuration

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -59,7 +59,7 @@ export default async function createConfigAsync() {
             // Please change this to your repo.
             // Remove this to remove the "edit this page" links.
             remarkPlugins: [mdx_mermaid],
-            editUrl: "https://github.com/hypercerts-org/hypercerts",
+            editUrl: "https://github.com/hypercerts-org/hypercerts/edit/main/docs/",
           },
           theme: {
             customCss: "./src/css/custom.css",


### PR DESCRIPTION
The URL for the "edit this page" link in the Docusaurus configuration has been updated. Previously, the link pointed to the root repository, but now it leads directly to the editable document in the docs directory of the main branch.