### PR TITLE
Bugfix in signature validations marketplace

### DIFF
--- a/contracts/audits/marketplace/2024_05_29_signature_bug.md
+++ b/contracts/audits/marketplace/2024_05_29_signature_bug.md
@@ -1,0 +1,52 @@
+## Issue
+
+When a user has set the approvals on the marketplace, an attacker could submit a transaction signed by the attacker for
+the (partial) sale of a hypercert fraction. The attacker would receive the funds, the order taker would receive the
+fraction and the fraction owner would lose -a part of- the fraction.
+
+## Fix
+
+To mitigate this, we added a check on the split method. Specifically, a check on ownership of or approval on the
+fraction by the signer of the message by calling the HyperMinter contract at time of order execution.
+
+```solidity
+if (
+    from != IHypercert1155Token(collection).ownerOf(itemIds[0])
+        && !IHypercert1155Token(collection).isApprovedForAll(
+            IHypercert1155Token(collection).ownerOf(itemIds[0]), from)
+    ) {
+        revert OrderInvalid();
+    }
+```
+
+The vulnerability is specific to the split function call because there is no check on the `operator` or `msg.sender`
+relations/approval as common in the `transferFrom` methods. This is an artifact from changing the original design where
+only the owner or somebody allowed by the owner would be able to split. The marketplace widens the attack vector because
+anybody can operate the marketplace, compared to a trusted operator you specifically set the approval for.
+
+To validate the changes, tests have been added to the TransferManager and one on the protocol level for 721 as a sanity
+check.
+
+## Additional information
+
+### `libraries/IHypercert1155Token.sol`
+
+- Because the check required calls to the HyperMinter not specified in the protocol interface, since the
+  `approvalForAll` call is part of the 1155 spec, we've added an interface file to the marketplace contract directory.
+- As we have the custom inferface file in the marketplace, imports from the `procotol` directory have been replaced with
+  the custom interface file.
+
+### Remove unused imports
+
+- Removed unused imports from the `IHypercertToken.sol` file
+
+### Replaced `_assertMerkleTreeAssumptions`
+
+- Unrelated tests on `BatchMakerOrders` failed with the following error:
+  `[FAIL. Reason: The `vm.assume` cheatcode rejected too many inputs (65536 allowed)]`
+- Replace the assumption with bounded variables:
+
+```solidity
+    numberOrders = bound(numberOrders, 1, 2 ** MAX_CALLDATA_PROOF_LENGTH);
+    orderIndex = bound(orderIndex, 0, numberOrders - 1);
+```

--- a/contracts/src/marketplace/ExecutionManager.sol
+++ b/contracts/src/marketplace/ExecutionManager.sol
@@ -7,7 +7,6 @@ import {OrderStructs} from "./libraries/OrderStructs.sol";
 // Interfaces
 import {IExecutionManager} from "./interfaces/IExecutionManager.sol";
 import {ICreatorFeeManager} from "./interfaces/ICreatorFeeManager.sol";
-import {IHypercertToken} from "../protocol/interfaces/IHypercertToken.sol";
 
 // Direct dependencies
 import {InheritedStrategy} from "./InheritedStrategy.sol";

--- a/contracts/src/marketplace/LooksRareProtocol.sol
+++ b/contracts/src/marketplace/LooksRareProtocol.sol
@@ -16,7 +16,7 @@ import {OrderStructs} from "./libraries/OrderStructs.sol";
 
 // Interfaces
 import {ILooksRareProtocol} from "./interfaces/ILooksRareProtocol.sol";
-import {IHypercertToken} from "../protocol/interfaces/IHypercertToken.sol";
+import {IHypercert1155Token} from "./interfaces/IHypercert1155Token.sol";
 
 // Shared errors
 import {
@@ -709,7 +709,7 @@ contract LooksRareProtocol is
         returns (uint256 unitsHeldByItems)
     {
         for (uint256 i; i < itemIds.length;) {
-            unitsHeldByItems += IHypercertToken(collection).unitsOf(itemIds[i]);
+            unitsHeldByItems += IHypercert1155Token(collection).unitsOf(itemIds[i]);
 
             unchecked {
                 ++i;

--- a/contracts/src/marketplace/TransferSelectorNFT.sol
+++ b/contracts/src/marketplace/TransferSelectorNFT.sol
@@ -14,9 +14,6 @@ import {CollectionTypeInvalid} from "./errors/SharedErrors.sol";
 // Enums
 import {CollectionType} from "./enums/CollectionType.sol";
 
-// Interfaces
-import {IHypercertToken} from "../protocol/interfaces/IHypercertToken.sol";
-
 /**
  * @title TransferSelectorNFT
  * @notice This contract handles the logic for transferring non-fungible items.

--- a/contracts/src/marketplace/executionStrategies/StrategyHypercertCollectionOffer.sol
+++ b/contracts/src/marketplace/executionStrategies/StrategyHypercertCollectionOffer.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 // Interface
-import {IHypercertToken} from "@hypercerts/protocol/interfaces/IHypercertToken.sol";
+import {IHypercert1155Token} from "../interfaces/IHypercert1155Token.sol";
 
 // Libraries
 import {OrderStructs} from "../libraries/OrderStructs.sol";
@@ -74,7 +74,7 @@ contract StrategyHypercertCollectionOffer is BaseStrategy {
         // A collection order can only be executable for 1 fraction
         if (
             amounts.length != 1 || amounts[0] != 1 || itemUnitsTaker != itemUnitsMaker
-                || IHypercertToken(makerBid.collection).unitsOf(offeredItemId) != itemUnitsMaker
+                || IHypercert1155Token(makerBid.collection).unitsOf(offeredItemId) != itemUnitsMaker
         ) {
             revert OrderInvalid();
         }
@@ -117,7 +117,7 @@ contract StrategyHypercertCollectionOffer is BaseStrategy {
         // A collection order can only be executable for 1 fraction
         if (
             amounts.length != 1 || amounts[0] != 1 || itemUnitsTaker != itemUnitsMaker
-                || IHypercertToken(makerBid.collection).unitsOf(offeredItemId) != itemUnitsMaker
+                || IHypercert1155Token(makerBid.collection).unitsOf(offeredItemId) != itemUnitsMaker
         ) {
             revert OrderInvalid();
         }
@@ -193,7 +193,7 @@ contract StrategyHypercertCollectionOffer is BaseStrategy {
         // A collection order can only be executable for 1 fraction
         if (
             amounts.length != 1 || amounts[0] != 1 || itemUnitsTaker != itemUnitsMaker
-                || IHypercertToken(collection).unitsOf(offeredItemId) != itemUnitsMaker
+                || IHypercert1155Token(collection).unitsOf(offeredItemId) != itemUnitsMaker
         ) {
             revert OrderInvalid();
         }

--- a/contracts/src/marketplace/executionStrategies/StrategyHypercertDutchAuction.sol
+++ b/contracts/src/marketplace/executionStrategies/StrategyHypercertDutchAuction.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 // Interface
-import {IHypercertToken} from "@hypercerts/protocol/interfaces/IHypercertToken.sol";
+import {IHypercert1155Token} from "../interfaces/IHypercert1155Token.sol";
 
 // Libraries
 import {OrderStructs} from "../libraries/OrderStructs.sol";
@@ -64,7 +64,7 @@ contract StrategyHypercertDutchAuction is BaseStrategy {
 
         uint256 unitsPerItemLength = unitsPerItem.length;
         for (uint256 i; i < unitsPerItemLength;) {
-            if (IHypercertToken(makerAsk.collection).unitsOf(makerAsk.itemIds[i]) != unitsPerItem[i]) {
+            if (IHypercert1155Token(makerAsk.collection).unitsOf(makerAsk.itemIds[i]) != unitsPerItem[i]) {
                 revert OrderInvalid();
             }
             unchecked {
@@ -124,7 +124,7 @@ contract StrategyHypercertDutchAuction is BaseStrategy {
 
         for (uint256 i; i < itemIdsLength;) {
             _validateAmountNoRevert(makerAsk.amounts[i], makerAsk.collectionType);
-            if ((IHypercertToken(makerAsk.collection).unitsOf(makerAsk.itemIds[i]) != unitsPerItem[i])) {
+            if ((IHypercert1155Token(makerAsk.collection).unitsOf(makerAsk.itemIds[i]) != unitsPerItem[i])) {
                 return (isValid, OrderInvalid.selector);
             }
             unchecked {

--- a/contracts/src/marketplace/executionStrategies/StrategyHypercertFractionOffer.sol
+++ b/contracts/src/marketplace/executionStrategies/StrategyHypercertFractionOffer.sol
@@ -23,13 +23,7 @@ import {
 // Base strategy contracts
 import {BaseStrategy, IStrategy} from "./BaseStrategy.sol";
 
-interface IHypercert1155Token {
-    function unitsOf(uint256 tokenId) external view returns (uint256);
-
-    function ownerOf(uint256 tokenId) external view returns (address);
-
-    function isApprovedForAll(address account, address operator) external view returns (bool);
-}
+import {IHypercert1155Token} from "../interfaces/IHypercert1155Token.sol";
 
 /**
  * @title StrategyHypercertFractionOffer
@@ -180,16 +174,6 @@ contract StrategyHypercertFractionOffer is BaseStrategy {
 
         if (makerAsk.amounts[0] != 1) {
             revert AmountInvalid();
-        }
-
-        //TODO Apply to other HC strats
-        if (
-            makerAsk.signer != IHypercert1155Token(makerAsk.collection).ownerOf(itemIds[0])
-                && !IHypercert1155Token(makerAsk.collection).isApprovedForAll(
-                    IHypercert1155Token(makerAsk.collection).ownerOf(itemIds[0]), makerAsk.signer
-                )
-        ) {
-            revert OrderInvalid();
         }
 
         //units, pricePerUnit, proof[]

--- a/contracts/src/marketplace/helpers/OrderValidatorV2A.sol
+++ b/contracts/src/marketplace/helpers/OrderValidatorV2A.sol
@@ -16,7 +16,6 @@ import {MerkleProofCalldataWithNodes} from "../libraries/OpenZeppelin/MerkleProo
 import {ICreatorFeeManager} from "../interfaces/ICreatorFeeManager.sol";
 import {IStrategy} from "../interfaces/IStrategy.sol";
 import {IRoyaltyFeeRegistry} from "../interfaces/IRoyaltyFeeRegistry.sol";
-import {IHypercertToken} from "@hypercerts/protocol/interfaces/IHypercertToken.sol";
 
 // Shared errors
 import {OrderInvalid, CollectionTypeInvalid} from "../errors/SharedErrors.sol";

--- a/contracts/src/marketplace/helpers/ProtocolHelpers.sol
+++ b/contracts/src/marketplace/helpers/ProtocolHelpers.sol
@@ -10,9 +10,6 @@ import {OrderStructs} from "../libraries/OrderStructs.sol";
 // Other dependencies
 import {LooksRareProtocol} from "../LooksRareProtocol.sol";
 
-// Interfaces
-import {IHypercertToken} from "@hypercerts/protocol/interfaces/IHypercertToken.sol";
-
 /**
  * @title ProtocolHelpers
  * @notice This contract contains helper view functions for order creation.

--- a/contracts/src/marketplace/interfaces/IHypercert1155Token.sol
+++ b/contracts/src/marketplace/interfaces/IHypercert1155Token.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+interface IHypercert1155Token {
+    function splitFraction(address to, uint256 tokenID, uint256[] memory _values) external;
+
+    function unitsOf(uint256 tokenId) external view returns (uint256);
+
+    function ownerOf(uint256 tokenId) external view returns (address);
+
+    function isApprovedForAll(address account, address operator) external view returns (bool);
+}

--- a/contracts/src/marketplace/libraries/LowLevelHypercertCaller.sol
+++ b/contracts/src/marketplace/libraries/LowLevelHypercertCaller.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 // Interfaces
-import {IHypercertToken} from "../../protocol/interfaces/IHypercertToken.sol";
+import {IHypercert1155Token} from "../interfaces/IHypercert1155Token.sol";
 
 /**
  * @title LowLevelHypercertCaller
@@ -27,7 +27,7 @@ contract LowLevelHypercertCaller {
             revert NotAContract();
         }
 
-        (bool status,) = collection.call(abi.encodeCall(IHypercertToken.splitFraction, (to, tokenId, amounts)));
+        (bool status,) = collection.call(abi.encodeCall(IHypercert1155Token.splitFraction, (to, tokenId, amounts)));
 
         if (!status) {
             revert HypercertSplitFractionError();

--- a/contracts/test/foundry/marketplace/BatchMakerOrders.t.sol
+++ b/contracts/test/foundry/marketplace/BatchMakerOrders.t.sol
@@ -39,7 +39,8 @@ contract BatchMakerOrdersTest is ProtocolBase {
     }
 
     function testTakerBidMultipleOrdersSignedERC721(uint256 numberOrders, uint256 orderIndex) public {
-        _assertMerkleTreeAssumptions(numberOrders, orderIndex);
+        numberOrders = bound(numberOrders, 1, 2 ** MAX_CALLDATA_PROOF_LENGTH);
+        orderIndex = bound(orderIndex, 0, numberOrders - 1);
 
         mockERC721.batchMint(makerUser, numberOrders);
 
@@ -75,7 +76,8 @@ contract BatchMakerOrdersTest is ProtocolBase {
     }
 
     function testTakerAskMultipleOrdersSignedERC721(uint256 numberOrders, uint256 orderIndex) public {
-        _assertMerkleTreeAssumptions(numberOrders, orderIndex);
+        numberOrders = bound(numberOrders, 1, 2 ** MAX_CALLDATA_PROOF_LENGTH);
+        orderIndex = bound(orderIndex, 0, numberOrders - 1);
 
         mockERC721.batchMint(takerUser, numberOrders);
 
@@ -111,7 +113,8 @@ contract BatchMakerOrdersTest is ProtocolBase {
     function testTakerBidMultipleOrdersSignedERC721MerkleProofInvalid(uint256 numberOrders, uint256 orderIndex)
         public
     {
-        _assertMerkleTreeAssumptions(numberOrders, orderIndex);
+        numberOrders = bound(numberOrders, 1, 2 ** MAX_CALLDATA_PROOF_LENGTH);
+        orderIndex = bound(orderIndex, 0, numberOrders - 1);
 
         mockERC721.batchMint(makerUser, numberOrders);
 
@@ -138,7 +141,8 @@ contract BatchMakerOrdersTest is ProtocolBase {
     function testTakerAskMultipleOrdersSignedERC721MerkleProofInvalid(uint256 numberOrders, uint256 orderIndex)
         public
     {
-        _assertMerkleTreeAssumptions(numberOrders, orderIndex);
+        numberOrders = bound(numberOrders, 1, 2 ** MAX_CALLDATA_PROOF_LENGTH);
+        orderIndex = bound(orderIndex, 0, numberOrders - 1);
 
         mockERC721.batchMint(takerUser, numberOrders);
 
@@ -165,7 +169,8 @@ contract BatchMakerOrdersTest is ProtocolBase {
     function testTakerBidMultipleOrdersSignedERC721MerkleProofWrongPosition(uint256 numberOrders, uint256 orderIndex)
         public
     {
-        _assertMerkleTreeAssumptions(numberOrders, orderIndex);
+        numberOrders = bound(numberOrders, 1, 2 ** MAX_CALLDATA_PROOF_LENGTH);
+        orderIndex = bound(orderIndex, 0, numberOrders - 1);
 
         mockERC721.batchMint(makerUser, numberOrders);
 
@@ -199,7 +204,8 @@ contract BatchMakerOrdersTest is ProtocolBase {
     function testTakerAskMultipleOrdersSignedERC721MerkleProofWrongPosition(uint256 numberOrders, uint256 orderIndex)
         public
     {
-        _assertMerkleTreeAssumptions(numberOrders, orderIndex);
+        numberOrders = bound(numberOrders, 1, 2 ** MAX_CALLDATA_PROOF_LENGTH);
+        orderIndex = bound(orderIndex, 0, numberOrders - 1);
 
         mockERC721.batchMint(takerUser, numberOrders);
 

--- a/contracts/test/foundry/marketplace/ProtocolBase.t.sol
+++ b/contracts/test/foundry/marketplace/ProtocolBase.t.sol
@@ -38,8 +38,16 @@ contract ProtocolBase is MockOrderGenerator, ILooksRareProtocol {
     MockHypercertMinterUUPS public mockHypercertMinterUUPS;
     HypercertMinter public mockHypercertMinter;
 
+    // enum TransferRestrictions {
+    //     AllowAll,
+    //     DisallowAll,
+    //     FromCreatorOnly
+    // }
+
     IHypercertToken.TransferRestrictions public constant FROM_CREATOR_ONLY =
         IHypercertToken.TransferRestrictions.FromCreatorOnly;
+
+    IHypercertToken.TransferRestrictions public constant ALLOW_ALL = IHypercertToken.TransferRestrictions.AllowAll;
 
     ProtocolFeeRecipient public protocolFeeRecipient;
     LooksRareProtocol public looksRareProtocol;


### PR DESCRIPTION
This PR covers the bug discussed in #1317 

When a user has set the approvals on the marketplace, an attacker could submit a transaction signed by the attacker for the (partial) sale of a hypercert fraction. The attacker would receive the funds, the order taker would receive the fraction and the fraction owner would lose a bit of the fraction.

To mitigate this, we added checks on the hypercert strategies where needed. Specifically, a check on ownership of the fraction by the signer of the message by calling the HyperMinter contract at time of order execution.

The vulnerability is specific to the split function call because there is not check there on the operator-msg.sender relations/approval as common in the transferFrom methods. This is an artifact from changing the original design where only the owner or somebody allowed by the owner would be able to split. The marketplace widens the attack vector because anybody can operate the marketplace, compared to a trusted operator you specifically set the approval for.

To validate the changes, tests have been added to each hypercert strategy and one on the protocol level for 721 as a sanity check.