### PR TITLE
liron's little fixes

### DIFF
--- a/contracts/src/protocol/SemiFungible1155.sol
+++ b/contracts/src/protocol/SemiFungible1155.sol
@@ -288,7 +288,6 @@ contract SemiFungible1155 is
      * @param _account The address of the account that will receive the new tokens.
      * @param _tokenID The ID of the token to split.
      * @param _values An array of numbers of units associated with the new tokens.
-     * @dev This function splits a token into multiple tokens with different unit values.
      * @dev The `_values` array specifies the number of units associated with each new token.
      * @dev The function checks that the length of the `_values` array is between 2 and `FRACTION_LIMIT`, and that the
      * sum of the values in the `_values` array is equal to the number of units associated with the original token.

--- a/contracts/src/protocol/SemiFungible1155.sol
+++ b/contracts/src/protocol/SemiFungible1155.sol
@@ -88,7 +88,7 @@ contract SemiFungible1155 is
      * @dev Upper 128 bits identify base type ID, lower bits should be 0.
      */
     function isBaseType(uint256 tokenID) internal pure returns (bool) {
-        return (tokenID & TYPE_MASK == tokenID) && (tokenID & NF_INDEX_MASK == 0);
+        return (tokenID & NF_INDEX_MASK == 0);
     }
 
     /**

--- a/contracts/src/protocol/SemiFungible1155.sol
+++ b/contracts/src/protocol/SemiFungible1155.sol
@@ -536,7 +536,7 @@ contract SemiFungible1155 is
             uint256 _from = fromIDs[i];
             uint256 _to = toIDs[i];
 
-            if (isBaseType(_from)) revert Errors.NotAllowed();
+            if (isBaseType(_from) || isBaseType(_to)) revert Errors.NotAllowed();
             if (getBaseType(_from) != getBaseType(_to)) revert Errors.TypeMismatch();
             unchecked {
                 ++i;


### PR DESCRIPTION
- remove redundant check (both checks check that lower bits are 0)
- check that also the tokenID is not a base type in splitting/merging